### PR TITLE
feat: ignore trailing path segments after the parsable portion of a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A simple HTTP server that can be used to mock HTTP responses for testing purpose
 - [Response Injection (Tap Feature)](#response-injection-tap-feature)
 - [Rate Limiting](#rate-limiting)
 - [Logging](#logging)
+- [Flexible URL Matching](#flexible-url-matching)
 - [API Reference](#api-reference)
 - [About mockhttp.org](#about-mockhttporg)
 - [Contributing](#contributing)
@@ -607,6 +608,21 @@ You can also disable logging via the `LOGGING` environment variable:
 ```bash
 LOGGING=false node your-app.js
 ```
+
+# Flexible URL Matching
+
+MockHttp ignores trailing path segments that come after the parsable portion of a URL. This is useful when a client appends extra data to a known endpoint — instead of returning 404, MockHttp serves the closest matching route.
+
+For example, all of these are served by `/status/:code`:
+
+```
+GET /status/429
+GET /status/429/
+GET /status/429/foo
+GET /status/429/foo/bar
+```
+
+The rewrite preserves the query string and only triggers when a more specific route exists; URLs whose first path segment doesn't correspond to a registered route still return 404.
 
 # API Reference
 

--- a/src/fastify-config.ts
+++ b/src/fastify-config.ts
@@ -21,22 +21,28 @@ export function rewriteUrl(
 		return originalUrl;
 	}
 
-	if (isSpecificMatch(this.findRoute({ method, url: originalUrl }))) {
-		return originalUrl;
-	}
-
 	const queryIdx = originalUrl.indexOf("?");
 	const path = queryIdx >= 0 ? originalUrl.slice(0, queryIdx) : originalUrl;
 	const query = queryIdx >= 0 ? originalUrl.slice(queryIdx) : "";
 
+	if (isSpecificMatch(this.findRoute({ method, url: path }))) {
+		return originalUrl;
+	}
+
 	const segments = path.split("/").filter(Boolean);
 
-	while (segments.length > 1) {
-		segments.pop();
+	while (segments.length >= 1) {
 		const candidatePath = `/${segments.join("/")}`;
-		if (isSpecificMatch(this.findRoute({ method, url: candidatePath }))) {
+		if (
+			candidatePath !== path &&
+			isSpecificMatch(this.findRoute({ method, url: candidatePath }))
+		) {
 			return candidatePath + query;
 		}
+		if (segments.length === 1) {
+			break;
+		}
+		segments.pop();
 	}
 
 	return originalUrl;

--- a/src/fastify-config.ts
+++ b/src/fastify-config.ts
@@ -1,3 +1,47 @@
+import type { IncomingMessage } from "node:http";
+import type { FastifyInstance } from "fastify";
+
+function isSpecificMatch(
+	route: ReturnType<FastifyInstance["findRoute"]> | null,
+): boolean {
+	if (!route) {
+		return false;
+	}
+	const params = route.params as Record<string, unknown> | undefined;
+	return params === undefined || params["*"] === undefined;
+}
+
+export function rewriteUrl(
+	this: FastifyInstance,
+	req: IncomingMessage,
+): string {
+	const originalUrl = req.url ?? "/";
+	const method = req.method;
+	if (!method) {
+		return originalUrl;
+	}
+
+	if (isSpecificMatch(this.findRoute({ method, url: originalUrl }))) {
+		return originalUrl;
+	}
+
+	const queryIdx = originalUrl.indexOf("?");
+	const path = queryIdx >= 0 ? originalUrl.slice(0, queryIdx) : originalUrl;
+	const query = queryIdx >= 0 ? originalUrl.slice(queryIdx) : "";
+
+	const segments = path.split("/").filter(Boolean);
+
+	while (segments.length > 1) {
+		segments.pop();
+		const candidatePath = `/${segments.join("/")}`;
+		if (isSpecificMatch(this.findRoute({ method, url: candidatePath }))) {
+			return candidatePath + query;
+		}
+	}
+
+	return originalUrl;
+}
+
 export function getFastifyConfig(logging = true) {
 	return {
 		logger: logging
@@ -13,5 +57,6 @@ export function getFastifyConfig(logging = true) {
 					},
 				}
 			: false,
+		rewriteUrl,
 	};
 }

--- a/test/fastify-config.test.ts
+++ b/test/fastify-config.test.ts
@@ -1,0 +1,153 @@
+import Fastify from "fastify";
+import { describe, expect, it } from "vitest";
+import { getFastifyConfig, rewriteUrl } from "../src/fastify-config.js";
+
+describe("getFastifyConfig", () => {
+	it("returns logger config when logging is enabled (default)", () => {
+		const config = getFastifyConfig();
+		expect(config.logger).not.toBe(false);
+		expect(config.rewriteUrl).toBe(rewriteUrl);
+	});
+
+	it("disables the logger when logging is false", () => {
+		const config = getFastifyConfig(false);
+		expect(config.logger).toBe(false);
+	});
+});
+
+describe("rewriteUrl", () => {
+	const buildFastify = () => {
+		const fastify = Fastify({ logger: false, rewriteUrl });
+		fastify.get("/status/:code?", async () => ({ ok: true }));
+		fastify.post("/status/:code?", async () => ({ ok: true }));
+		fastify.get("/anything", async () => ({ ok: true }));
+		fastify.get("/links/:n/:offset?", async () => ({ ok: true }));
+		fastify.get("/", async () => ({ ok: true }));
+		return fastify;
+	};
+
+	it("rewrites trailing segments to the parsable portion of the URL", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/status/429/foo",
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ ok: true });
+		await fastify.close();
+	});
+
+	it("rewrites a trailing slash variant of an unknown extension", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/status/429/foo/",
+		});
+		expect(response.statusCode).toBe(200);
+		await fastify.close();
+	});
+
+	it("rewrites several trailing segments down to a known route", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/status/200/foo/bar/baz",
+		});
+		expect(response.statusCode).toBe(200);
+		await fastify.close();
+	});
+
+	it("preserves the query string when rewriting", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/status/200/foo?show_env=1",
+		});
+		expect(response.statusCode).toBe(200);
+		await fastify.close();
+	});
+
+	it("respects the HTTP method when matching", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/status/201/extra",
+		});
+		expect(response.statusCode).toBe(200);
+		await fastify.close();
+	});
+
+	it("does not rewrite when the URL already matches a route", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/anything",
+		});
+		expect(response.statusCode).toBe(200);
+		await fastify.close();
+	});
+
+	it("returns 404 when no prefix of the URL matches a route", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/totally/unknown/path",
+		});
+		expect(response.statusCode).toBe(404);
+		await fastify.close();
+	});
+
+	it("does not strip the first segment down to the root", async () => {
+		const fastify = buildFastify();
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/unknown-root",
+		});
+		expect(response.statusCode).toBe(404);
+		await fastify.close();
+	});
+
+	it("prefers a specific route over a wildcard catch-all when stripping", async () => {
+		const fastify = Fastify({ logger: false, rewriteUrl });
+		fastify.get("/status/:code", async () => ({ matched: "status" }));
+		fastify.get("/*", async () => ({ matched: "wildcard" }));
+		await fastify.ready();
+
+		const stripped = await fastify.inject({
+			method: "GET",
+			url: "/status/200/extra",
+		});
+		expect(stripped.json()).toEqual({ matched: "status" });
+
+		const wildcardOnly = await fastify.inject({
+			method: "GET",
+			url: "/unknown/path",
+		});
+		expect(wildcardOnly.json()).toEqual({ matched: "wildcard" });
+
+		await fastify.close();
+	});
+
+	it("returns the original URL when the method is missing", () => {
+		const fakeFastify = {
+			findRoute: () => null,
+		} as unknown as Parameters<typeof rewriteUrl>[0] extends never
+			? never
+			: import("fastify").FastifyInstance;
+		const result = rewriteUrl.call(fakeFastify, {
+			url: "/status/429/foo",
+			method: undefined,
+		} as unknown as import("node:http").IncomingMessage);
+		expect(result).toBe("/status/429/foo");
+	});
+
+	it("returns '/' when the request URL is missing", () => {
+		const fakeFastify = {
+			findRoute: () => null,
+		} as unknown as import("fastify").FastifyInstance;
+		const result = rewriteUrl.call(fakeFastify, {
+			method: "GET",
+		} as unknown as import("node:http").IncomingMessage);
+		expect(result).toBe("/");
+	});
+});

--- a/test/fastify-config.test.ts
+++ b/test/fastify-config.test.ts
@@ -47,6 +47,23 @@ describe("rewriteUrl", () => {
 		await fastify.close();
 	});
 
+	it("rewrites a trailing-slash-only path to the segments without the slash", async () => {
+		const fastify = Fastify({ logger: false, rewriteUrl });
+		fastify.get("/status/:code", async (request) => ({
+			params: request.params,
+		}));
+		fastify.get("/*", async () => ({ matched: "wildcard" }));
+		await fastify.ready();
+
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/status/429/",
+		});
+		expect(response.json()).toEqual({ params: { code: "429" } });
+
+		await fastify.close();
+	});
+
 	it("rewrites several trailing segments down to a known route", async () => {
 		const fastify = buildFastify();
 		const response = await fastify.inject({

--- a/test/mock-http.test.ts
+++ b/test/mock-http.test.ts
@@ -90,6 +90,29 @@ describe("MockHttp", () => {
 		await mock2.close();
 	});
 
+	test("should ignore trailing path segments after the parsable portion", async () => {
+		const mock = new MockHttp({ logging: false });
+		await mock.start();
+
+		const response = await mock.server.inject({
+			method: "GET",
+			url: "/status/429/foo",
+		});
+
+		expect(response.statusCode).toBe(429);
+		expect(response.json()).toEqual({
+			status: "Response with status code 429",
+		});
+
+		const unknown = await mock.server.inject({
+			method: "GET",
+			url: "/totally/unknown/path",
+		});
+		expect(unknown.statusCode).toBe(404);
+
+		await mock.close();
+	});
+
 	describe("injection/tap feature", () => {
 		test("should be able to set taps property", () => {
 			const mock = new MockHttp();


### PR DESCRIPTION
## Summary

- Adds a Fastify `rewriteUrl` hook in `src/fastify-config.ts` that, when a request URL doesn't match a specific route (only the static catch-all wildcard or nothing), progressively strips trailing path segments and rewrites to the first specific route prefix that matches.
- Resolves #137: `/status/429/foo` (or `/status/429/foo/bar/`) is now served by the `/status/:code` handler with status code 429, just like `/status/429`.
- Query strings are preserved, and the first path segment is never stripped, so genuinely unknown URLs still return 404 instead of collapsing to `/`.
- A wildcard catch-all match (e.g. the static-file handler at `/*`) is treated as "no specific match", so a stripped candidate that matches a real route wins over the wildcard. Otherwise the original URL is returned and the wildcard still serves it.

## Test plan

- [x] `pnpm test` (412 tests pass, 100% line coverage; `src/fastify-config.ts` fully covered)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] New unit tests in `test/fastify-config.test.ts` cover: trailing segment(s), trailing slash, query string preservation, method matching, no-rewrite when URL already matches, 404 on completely unknown paths, no-strip-to-root, missing method, missing URL, and wildcard-vs-specific precedence.
- [x] New integration test in `test/mock-http.test.ts` confirms `/status/429/foo` returns 429 and `/totally/unknown/path` still returns 404 on a full `MockHttp` instance.

https://claude.ai/code/session_01V1j124Md6c76NjGTzHznmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1j124Md6c76NjGTzHznmL)_