### PR TITLE
release: v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jaredwray/mockhttp",
-	"version": "1.5.1",
+	"version": "1.6.0",
 	"description": "Mock Http - Easy way to mock http with httpbin replacement",
 	"type": "module",
 	"main": "dist/index.mjs",


### PR DESCRIPTION
## Release summary
Flexible URL matching: trailing path segments fall back to the parsable route prefix (fixes #137).

## Release notes (copy-pasteable for the GitHub Release)

````md
## @jaredwray/mockhttp@1.6.0 — 2026-05-16

Flexible URL matching: trailing path segments fall back to the parsable route prefix (fixes #137).

### Features
- ignore trailing path segments after the parsable portion (`6f82897`, #139)

  A Fastify `rewriteUrl` hook progressively strips trailing segments when only the static catch-all wildcard or nothing matches. Query strings are preserved and the first path segment is never stripped, so genuinely unknown URLs still 404.

  ```http
  # Before — only an exact match worked:
  GET /status/429        → 429
  GET /status/429/foo    → 404

  # After — trailing segments fall back to the parsable prefix:
  GET /status/429        → 429
  GET /status/429/foo    → 429   (served by /status/:code)
  GET /status/429/foo/bar/ → 429
  GET /status/429?x=1    → 429   (query preserved)
  GET /totally/unknown   → 404   (first segment never stripped)
  ```

### Documentation
- document flexible URL matching behavior in the README (`148ed17`, #139)

### Internal
- extract query string before initial route check; add trailing-slash path coverage (`5f298ea`, #139)
- fix typos in README and `src/swagger.ts` (`be2b014`, #138)

### Contributors
- @jaredwray — #139
- @mrazauskas — #138 (first contribution 🎉)

**Full diff:** https://github.com/jaredwray/mockhttp/compare/v1.5.1...v1.6.0
````

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds (`dist/index.mjs` 103.49 kB)
- [x] `pnpm test:ci` passes (413 / 413 tests; 100% line coverage)
- [x] No uncommitted changes outside the `package.json` version bump

## Post-merge
Merge then create a GitHub Release at tag `v1.6.0` — the `release.yaml` workflow (triggered on `release: released`) publishes to npm. Paste the markdown block above straight into the Release body.

## Cut with
First end-to-end run of [`release-cut.md`](https://github.com/jaredwray/agentic/blob/main/release-cut.md) (now updated with the code-examples rule in jaredwray/agentic#4 and the four-backtick wrapper fix in jaredwray/agentic#5).

https://claude.ai/code/session_01AnFVx45a2t4rYVSP6WgNEj