### PR TITLE
root - chore: upgrade hookified

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@scalar/api-reference": "^1.55.3",
 		"detect-port": "^2.1.0",
 		"fastify": "^5.8.5",
-		"hookified": "^2.1.1",
+		"hookified": "^2.2.0",
 		"html-escaper": "^3.0.3",
 		"pino": "^10.3.1",
 		"pino-pretty": "^13.1.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^5.8.5
         version: 5.8.5
       hookified:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       html-escaper:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1873,8 +1873,8 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
-  hookified@2.1.1:
-    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -4892,7 +4892,7 @@ snapshots:
 
   hookable@6.1.1: {}
 
-  hookified@2.1.1: {}
+  hookified@2.2.0: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary
Upgrade `hookified` to its latest release.

## Versions
- `hookified` 2.1.1 → 2.2.0

## Tests
- [x] `pnpm test` passes (413 tests)
- [x] `pnpm build` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01M76AJbXbiw911Dy8PbmrFU)_