### PR TITLE
release: v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jaredwray/mockhttp",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "Mock Http - Easy way to mock http with httpbin replacement",
 	"type": "module",
 	"main": "dist/index.mjs",


### PR DESCRIPTION
## Release summary
Routine maintenance: dependency refresh (fastify, @scalar/api-reference, hookified), pnpm 11 supply-chain baseline, and GitHub Actions major upgrades.

## @jaredwray/mockhttp@1.6.1 — 2026-05-18

Routine maintenance: dependency refresh (fastify, @scalar/api-reference, hookified), pnpm 11 supply-chain baseline, and GitHub Actions major upgrades.

### Internal
- upgrade hookified 2.1.1 → 2.2.0 (`e431858`, #147)
- upgrade @scalar/api-reference 1.52.1 → 1.55.3 (`e07afea`, #146)
- upgrade @fastify/static 9.1.0→9.1.3, @fastify/swagger-ui 5.2.5→5.2.6, fastify 5.8.4→5.8.5 (`bcfddf6`, #145)
- upgrade GitHub Actions to latest majors (checkout v6, setup-node v6, upload-artifact v7, download-artifact v8, codeql v4, etc.) (`a47cf91`, #144)
- bump engines.node to >=22.18.0 for tsdown 0.22.0 (`5ab1512`, #143)
- upgrade TypeScript 6.0.2 → 6.0.3, tsdown 0.21.7 → 0.22.0, @swc/core 1.15.24 → 1.15.33 (`5cef6c7`, #143)
- upgrade Biome 2.4.11 → 2.4.15 and Vitest 4.1.4 → 4.1.6 (`edfdf90`, #142)
- disable setup-node v5 package-manager-cache to fix corepack ordering (`8bf7cd1`, #141)
- address review feedback on pnpm 11 upgrade (`ca65ce5`, #141)
- upgrade to pnpm 11 via corepack with defense-in-depth workspace baseline (`1d93b64`, #141)

### Contributors
- @jaredwray (10)

### Full List of Changes
- chore: upgrade to pnpm 11 via corepack with defense-in-depth workspace by @jaredwray in #141
- root - chore: upgrade code quality dependencies by @jaredwray in #142
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #143
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #144
- root - chore: upgrade fastify dependencies by @jaredwray in #145
- root - chore: upgrade @scalar/api-reference by @jaredwray in #146
- root - chore: upgrade hookified by @jaredwray in #147

**Full diff:** https://github.com/jaredwray/mockhttp/compare/v1.6.0...v1.6.1

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds (tsdown 0.22.0, target node22.18.0)
- [x] `pnpm test:ci` passes (413 tests, 100% line coverage)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge then create a GitHub Release at tag `v1.6.1` — the `release.yaml` workflow publishes to npm on the `release: released` event.

## Notes
- All commits since `v1.6.0` are `chore`/`ci` (no `feat:`/`fix:`); the shipping reason is the consumer-facing runtime dep bumps (fastify, @scalar/api-reference, hookified) plus the pnpm 11 / Actions baseline.
- The `engines.node` narrowing from `>=22.13.0` → `>=22.18.0` (forced by `tsdown 0.22.0`) is treated as patch — it's a 5-minor tightening within the Node 22 line. Strict semver could argue for minor; please override at merge if preferred.
- The `(breaking)` marker on #144 is CI-internal (Actions major bumps), not a consumer break.

---
_Generated by [Claude Code](https://claude.ai/code/session_015DZWCWwPWh2yDYQGJRppx6)_