### PR TITLE
ci(deploy-site): run test and build in parallel

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -28,7 +28,6 @@ jobs:
 
   build:
     name: Build
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -48,7 +47,7 @@ jobs:
 
   deploy:
     name: Deploy to Production
-    needs: build
+    needs: [test, build]
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## Summary

- `build` no longer waits on `test` — they now run in parallel.
- `deploy` now requires both `test` and `build` to succeed (`needs: [test, build]`), so the test gate is preserved while wall-clock time on a release drops to roughly `max(test, build) + deploy`.
- `build` never consumed any output from `test`, so this change is purely a scheduling optimization.

### Job graph

```
test ─┐
      ├──> deploy
build ┘
```

## Test plan

- [ ] Trigger `deploy-site` via `workflow_dispatch` and confirm `test` and `build` start in parallel and `deploy` waits for both.
- [ ] On a throwaway commit, force a failing test and confirm `deploy` is skipped.
- [ ] On a green run, confirm the `dist` artifact is uploaded by `build` and downloaded by `deploy` as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_0185FDCmz92yNBrbQRvSxV6V)_