### PR TITLE
feat: add request bins for inspecting captured HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A simple HTTP server that can be used to mock HTTP responses for testing purpose
 # Features
 * All the features of [httpbin](https://httpbin.org/)
 * Taps - Inject custom responses for testing and development
+* Bins - Capture and inspect incoming HTTP requests (great for webhook debugging)
 * `@fastify/helmet` built in by default
 * Built with `nodejs`, `typescript`, and `fastify`
 * Deploy via `docker` or `nodejs`
@@ -28,6 +29,7 @@ A simple HTTP server that can be used to mock HTTP responses for testing purpose
 - [HTTPS Support](#https-support)
 - [HTTP/2 Support](#http2-support)
 - [Response Injection (Tap Feature)](#response-injection-tap-feature)
+- [Request Bins](#request-bins)
 - [Rate Limiting](#rate-limiting)
 - [Logging](#logging)
 - [Flexible URL Matching](#flexible-url-matching)
@@ -435,8 +437,12 @@ const tap = mock.taps.inject(
 
 Bins are ephemeral URL endpoints that **capture incoming HTTP requests** so you
 can inspect them later. They're the inverse of Taps: instead of injecting a
-response, they record everything they receive. Useful for debugging webhooks,
-exercising client SDKs, or recording fixtures.
+response, they record everything they receive. Useful for:
+
+- **Debugging webhooks** — point Stripe / GitHub / Slack at a bin URL and see
+  exactly what they send
+- **Exercising client SDKs** — verify your SDK sends the request shape you expect
+- **Recording fixtures** — capture real traffic to replay in tests later
 
 There are two URL prefixes:
 
@@ -450,12 +456,15 @@ There are two URL prefixes:
 # 1. create a bin
 curl -s -X POST http://localhost:3000/bins
 # → { "id": "abc123def456", "url": "http://localhost:3000/b/abc123def456",
-#     "createdAt": "...", "expiresAt": "...", "requestCount": 0 }
+#     "createdAt": "2026-05-18T12:00:00.000Z",
+#     "expiresAt": "2026-05-19T12:00:00.000Z",
+#     "requestCount": 0 }
 
 # 2. send anything to the capture URL
 curl -X POST "http://localhost:3000/b/abc123def456/webhook?source=stripe" \
   -H 'content-type: application/json' \
   -d '{"event":"payment.succeeded"}'
+# → { "ok": true, "binId": "abc123def456", "requestId": "f9c2e1a40b3d" }
 
 # 3. list captured requests (newest first)
 curl http://localhost:3000/bins/abc123def456/requests
@@ -474,11 +483,66 @@ curl http://localhost:3000/bins/abc123def456/requests
 | DELETE | `/bins/:id` | Delete a bin |
 | ANY | `/b/:id` and `/b/:id/*` | Capture requests sent to a bin |
 
+## End-to-End Webhook Debugging Example
+
+A complete walkthrough using curl:
+
+```bash
+BASE=http://localhost:3000
+
+# Create the bin and grab its id
+ID=$(curl -s -X POST $BASE/bins | jq -r .id)
+echo "Bin URL: $BASE/b/$ID"
+
+# Simulate a Stripe webhook
+curl -s -X POST "$BASE/b/$ID/stripe/events?secret=whsec_test" \
+  -H 'content-type: application/json' \
+  -H 'stripe-signature: t=1700000000,v1=abc123' \
+  -d '{"id":"evt_1","type":"payment_intent.succeeded","data":{"object":{"amount":2000}}}'
+
+# Simulate a GitHub webhook
+curl -s -X POST "$BASE/b/$ID/github" \
+  -H 'content-type: application/json' \
+  -H 'x-github-event: pull_request' \
+  -d '{"action":"opened","number":42}'
+
+# Inspect everything that arrived
+curl -s "$BASE/bins/$ID/requests" | jq
+
+# Drill into the most recent one
+RID=$(curl -s "$BASE/bins/$ID/requests" | jq -r '.requests[0].id')
+curl -s "$BASE/bins/$ID/requests/$RID" | jq
+#   {
+#     "id": "f9c2e1a40b3d",
+#     "binId": "abc123def456",
+#     "method": "POST",
+#     "url": "/github",
+#     "path": "/github",
+#     "query": {},
+#     "headers": {
+#       "host": "localhost:3000",
+#       "content-type": "application/json",
+#       "x-github-event": "pull_request"
+#     },
+#     "remoteAddress": "127.0.0.1",
+#     "contentType": "application/json",
+#     "bodySize": 32,
+#     "body": "{\"action\":\"opened\",\"number\":42}",
+#     "bodyEncoding": "utf8",
+#     "truncated": false,
+#     "capturedAt": "2026-05-18T12:00:01.234Z"
+#   }
+
+# Clean up
+curl -s -X DELETE "$BASE/bins/$ID/requests"  # clear captures, keep the bin
+curl -s -X DELETE "$BASE/bins/$ID"           # delete the bin entirely
+```
+
 ## Captured Request Shape
 
 ```json
 {
-  "id": "req_abcd1234efgh",
+  "id": "f9c2e1a40b3d",
   "binId": "abc123def456",
   "method": "POST",
   "url": "/webhook?source=stripe",
@@ -495,6 +559,8 @@ curl http://localhost:3000/bins/abc123def456/requests
 }
 ```
 
+- **`url`** is the request URL relative to the bin (everything after `/b/:id`).
+- **`path`** is the sub-path only, without the query string.
 - **`bodyEncoding`** is `"utf8"` for text content types (text/*, application/json,
   application/xml, application/x-www-form-urlencoded, application/javascript),
   `"base64"` for everything else (binary payloads), or `"none"` when no body
@@ -502,44 +568,180 @@ curl http://localhost:3000/bins/abc123def456/requests
 - **`truncated`** is `true` when the body exceeded `maxBodySize` and was cut
   off. `bodySize` reflects the original length.
 
+## Body Encoding Examples
+
+### Text Content (UTF-8)
+
+JSON, XML, form-encoded, plain text, and JavaScript are stored as UTF-8 strings
+so you can read them directly:
+
+```bash
+curl -X POST "http://localhost:3000/b/$ID" \
+  -H 'content-type: application/json' \
+  -d '{"hello":"world"}'
+
+curl -s "http://localhost:3000/bins/$ID/requests" | jq '.requests[0] | {bodyEncoding, body}'
+# {
+#   "bodyEncoding": "utf8",
+#   "body": "{\"hello\":\"world\"}"
+# }
+```
+
+### Binary Content (Base64)
+
+Any non-text content type is base64-encoded, preserving the bytes exactly:
+
+```bash
+# Upload a PNG to the bin
+curl -X POST "http://localhost:3000/b/$ID/upload" \
+  -H 'content-type: image/png' \
+  --data-binary @logo.png
+
+curl -s "http://localhost:3000/bins/$ID/requests" | jq '.requests[0] | {bodyEncoding, bodySize}'
+# {
+#   "bodyEncoding": "base64",
+#   "bodySize": 14823
+# }
+
+# Decode the body back to bytes
+curl -s "http://localhost:3000/bins/$ID/requests" \
+  | jq -r '.requests[0].body' | base64 -d > recovered.png
+```
+
+### Truncation
+
+Bodies larger than `maxBodySize` (1 MiB by default) are cut off and flagged:
+
+```javascript
+// In test setup
+import { MockHttp, BinManager } from '@jaredwray/mockhttp';
+const mock = new MockHttp();
+mock.bins = new BinManager({ maxBodySize: 1024 }); // 1 KiB cap
+await mock.start();
+```
+
+```bash
+# Send 5000 bytes to a bin with a 1 KiB cap
+head -c 5000 /dev/urandom | curl -X POST "http://localhost:3000/b/$ID" \
+  -H 'content-type: application/octet-stream' \
+  --data-binary @-
+
+curl -s "http://localhost:3000/bins/$ID/requests" | jq '.requests[0] | {bodySize, truncated, body_len: (.body | length)}'
+# {
+#   "bodySize": 5000,        ← original size
+#   "truncated": true,
+#   "body_len": 1368         ← base64 of the first 1024 bytes
+# }
+```
+
+## FIFO Eviction Example
+
+Once a bin reaches `maxRequestsPerBin` captures (100 by default), the oldest
+ones are dropped:
+
+```bash
+# Send 105 requests
+for i in $(seq 1 105); do
+  curl -s -X POST "http://localhost:3000/b/$ID/event/$i" > /dev/null
+done
+
+# The bin holds the most recent 100; the first 5 are gone
+curl -s "http://localhost:3000/bins/$ID/requests" | jq '.requests | length'
+# 100
+
+# Newest is at the top
+curl -s "http://localhost:3000/bins/$ID/requests" | jq '.requests[0].path'
+# "/event/105"
+```
+
 ## Programmatic Access
 
-The bin manager is exposed on the `MockHttp` instance as `mock.bins`:
+The bin manager is exposed on the `MockHttp` instance as `mock.bins`. This
+makes it easy to drive bins from a test suite without going through HTTP:
 
 ```javascript
 import { MockHttp } from '@jaredwray/mockhttp';
 
-const mock = new MockHttp();
+const mock = new MockHttp({ logging: false });
 await mock.start();
 
-// Create a bin directly
+// Create a bin
 const bin = mock.bins.createBin();
-console.log(bin.id);
+console.log(`Webhook target: http://localhost:${mock.port}/b/${bin.id}`);
 
-// Read captured requests
+// ... point your code-under-test at that URL ...
+
+// Read captured requests (newest first)
 const requests = mock.bins.getRequests(bin.id);
+console.log(`Captured ${requests.length} requests`);
 
+for (const req of requests) {
+  console.log(`${req.method} ${req.path} (${req.bodySize} bytes)`);
+}
+
+// Clean up
+mock.bins.deleteBin(bin.id);
 await mock.close(); // also stops the bin cleanup timer
+```
+
+### Using Bins in a Vitest Test
+
+```typescript
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import { MockHttp } from '@jaredwray/mockhttp';
+
+let mock: MockHttp;
+
+beforeAll(async () => {
+  mock = new MockHttp({ logging: false });
+  await mock.start();
+});
+
+afterAll(async () => {
+  await mock.close();
+});
+
+test('my SDK sends the right webhook payload', async () => {
+  const bin = mock.bins.createBin();
+  const webhookUrl = `http://localhost:${mock.port}/b/${bin.id}`;
+
+  // Drive your SDK at the bin
+  await mySdk.notify(webhookUrl, { event: 'user.created', id: 42 });
+
+  // Assert on what actually arrived
+  const [captured] = mock.bins.getRequests(bin.id);
+  expect(captured.method).toBe('POST');
+  expect(captured.contentType).toBe('application/json');
+  expect(JSON.parse(captured.body!)).toEqual({
+    event: 'user.created',
+    id: 42,
+  });
+  expect(captured.headers['x-signature']).toBeDefined();
+});
 ```
 
 ## Configuration
 
-Bins can be disabled or tuned. Limits are passed via the `BinManager`
-constructor and require replacing the default manager:
+Bins are enabled by default. To disable the routes entirely:
+
+```javascript
+const mock = new MockHttp({
+  httpBin: { bins: false },
+});
+```
+
+To tune limits, replace the default `BinManager` before starting:
 
 ```javascript
 import { MockHttp, BinManager } from '@jaredwray/mockhttp';
 
-const mock = new MockHttp({
-  httpBin: { bins: true }, // default — set false to disable the routes entirely
-});
-
-// Replace the default manager with custom limits
+const mock = new MockHttp();
 mock.bins = new BinManager({
-  defaultTtlMs: 60 * 60 * 1000,   // 1 hour (default: 24h)
-  maxRequestsPerBin: 500,          // (default: 100)
-  maxBodySize: 5 * 1024 * 1024,    // 5 MiB (default: 1 MiB)
-  idLength: 16,                    // (default: 12)
+  defaultTtlMs: 60 * 60 * 1000,    // 1 hour (default: 24h)
+  maxRequestsPerBin: 500,           // (default: 100)
+  maxBodySize: 5 * 1024 * 1024,     // 5 MiB (default: 1 MiB)
+  idLength: 16,                     // (default: 12)
+  cleanupIntervalMs: 30 * 1000,     // sweep every 30s (default: 60s)
 });
 
 await mock.start();
@@ -562,11 +764,29 @@ backends (Redis, SQLite, etc.) without changing the rest of the codebase. The
 default `InMemoryBinStore` keeps state in process memory.
 
 ```typescript
-import { BinManager, type BinStore } from '@jaredwray/mockhttp';
+import {
+  BinManager,
+  InMemoryBinStore,
+  type Bin,
+  type BinStore,
+  type CapturedRequest,
+} from '@jaredwray/mockhttp';
 
-class MyStore implements BinStore { /* ... */ }
+class RedisBinStore implements BinStore {
+  createBin(bin: Bin): void { /* SET bin:${bin.id} ... */ }
+  getBin(id: string): Bin | undefined { /* GET ... */ }
+  listBins(): Bin[] { /* SCAN ... */ }
+  deleteBin(id: string): boolean { /* DEL ... */ }
+  addRequest(binId: string, req: CapturedRequest, max: number): void {
+    /* LPUSH bin:${binId}:requests + LTRIM to max */
+  }
+  getRequests(binId: string): CapturedRequest[] { /* LRANGE ... */ }
+  getRequest(binId: string, reqId: string): CapturedRequest | undefined { /* ... */ }
+  clearRequests(binId: string): void { /* DEL bin:${binId}:requests */ }
+  cleanupExpired(now: number): string[] { /* scan + delete */ return []; }
+}
 
-mock.bins = new BinManager({ store: new MyStore() });
+mock.bins = new BinManager({ store: new RedisBinStore() });
 ```
 
 # Rate Limiting
@@ -814,6 +1034,7 @@ new MockHttp(options?)
 - `http1`: boolean - Get/set HTTP/1.1 fallback for HTTP/2 with HTTPS
 - `server`: FastifyInstance - Get/set the Fastify server instance
 - `taps`: TapManager - Get/set the TapManager instance
+- `bins`: BinManager - Get/set the BinManager instance for request bins
 
 ### Methods
 
@@ -874,6 +1095,68 @@ Register authentication routes (basic, bearer, digest, hidden-basic).
 #### `async registerImageRoutes(fastifyInstance?)`
 
 Register image routes (jpeg, png, svg, webp) with content negotiation support.
+
+#### `async registerBinRoutes(fastifyInstance?)`
+
+Register the request bin routes — management at `/bins` and capture at `/b/:id`.
+
+## Bins (Request Capture)
+
+Access the BinManager via `mockHttp.bins` to manage request bins programmatically. See [Request Bins](#request-bins) for usage examples.
+
+### `bins.createBin()`
+
+Create a new bin with the configured TTL.
+
+**Returns:** `Bin` — `{ id, createdAt, expiresAt, requestCount }`
+
+### `bins.getBin(id)`
+
+Look up a bin by id. Returns `undefined` if the bin does not exist or has expired (and lazily removes the expired entry).
+
+**Returns:** `Bin | undefined`
+
+### `bins.listBins()`
+
+List all non-expired bins.
+
+**Returns:** `Bin[]`
+
+### `bins.deleteBin(id)`
+
+Delete a bin and all its captured requests.
+
+**Returns:** `boolean` — `true` if the bin existed
+
+### `bins.getRequests(binId)`
+
+List captured requests for a bin, newest first.
+
+**Returns:** `CapturedRequest[]`
+
+### `bins.getRequest(binId, reqId)`
+
+Look up a single captured request.
+
+**Returns:** `CapturedRequest | undefined`
+
+### `bins.clearRequests(binId)`
+
+Clear all captured requests in a bin (the bin itself is preserved).
+
+### `bins.recordRequest(binId, raw)`
+
+Manually record a captured request. Returns `undefined` if the bin does not exist or is expired. Normally invoked by the capture route, but available for programmatic use.
+
+**Returns:** `CapturedRequest | undefined`
+
+### `bins.start()` / `bins.stop()`
+
+Start or stop the periodic cleanup of expired bins. `MockHttp.start()` and `MockHttp.close()` call these automatically. The interval is `unref()`'d so it never keeps the Node process alive.
+
+### `bins.maxBodySize` / `bins.maxRequestsPerBin` / `bins.defaultTtlMs`
+
+Read-only getters for the currently-configured limits.
 
 ## Taps (Response Injection)
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,144 @@ const tap = mock.taps.inject(
 );
 ```
 
+# Request Bins
+
+Bins are ephemeral URL endpoints that **capture incoming HTTP requests** so you
+can inspect them later. They're the inverse of Taps: instead of injecting a
+response, they record everything they receive. Useful for debugging webhooks,
+exercising client SDKs, or recording fixtures.
+
+There are two URL prefixes:
+
+- **`/bins`** — JSON management API: create, list, inspect, delete bins
+- **`/b/:id`** — the capture URL. Any HTTP method, any sub-path, any body sent
+  here is stored against bin `:id`
+
+## Quick Start
+
+```bash
+# 1. create a bin
+curl -s -X POST http://localhost:3000/bins
+# → { "id": "abc123def456", "url": "http://localhost:3000/b/abc123def456",
+#     "createdAt": "...", "expiresAt": "...", "requestCount": 0 }
+
+# 2. send anything to the capture URL
+curl -X POST "http://localhost:3000/b/abc123def456/webhook?source=stripe" \
+  -H 'content-type: application/json' \
+  -d '{"event":"payment.succeeded"}'
+
+# 3. list captured requests (newest first)
+curl http://localhost:3000/bins/abc123def456/requests
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/bins` | Create a new bin |
+| GET | `/bins` | List all active bins |
+| GET | `/bins/:id` | Get bin metadata |
+| GET | `/bins/:id/requests` | List captured requests (newest first) |
+| GET | `/bins/:id/requests/:reqId` | Get a single captured request |
+| DELETE | `/bins/:id/requests` | Clear all captured requests in a bin |
+| DELETE | `/bins/:id` | Delete a bin |
+| ANY | `/b/:id` and `/b/:id/*` | Capture requests sent to a bin |
+
+## Captured Request Shape
+
+```json
+{
+  "id": "req_abcd1234efgh",
+  "binId": "abc123def456",
+  "method": "POST",
+  "url": "/webhook?source=stripe",
+  "path": "/webhook",
+  "query": { "source": "stripe" },
+  "headers": { "content-type": "application/json", "...": "..." },
+  "remoteAddress": "127.0.0.1",
+  "contentType": "application/json",
+  "bodySize": 32,
+  "body": "{\"event\":\"payment.succeeded\"}",
+  "bodyEncoding": "utf8",
+  "truncated": false,
+  "capturedAt": "2026-05-18T12:00:00.000Z"
+}
+```
+
+- **`bodyEncoding`** is `"utf8"` for text content types (text/*, application/json,
+  application/xml, application/x-www-form-urlencoded, application/javascript),
+  `"base64"` for everything else (binary payloads), or `"none"` when no body
+  was sent.
+- **`truncated`** is `true` when the body exceeded `maxBodySize` and was cut
+  off. `bodySize` reflects the original length.
+
+## Programmatic Access
+
+The bin manager is exposed on the `MockHttp` instance as `mock.bins`:
+
+```javascript
+import { MockHttp } from '@jaredwray/mockhttp';
+
+const mock = new MockHttp();
+await mock.start();
+
+// Create a bin directly
+const bin = mock.bins.createBin();
+console.log(bin.id);
+
+// Read captured requests
+const requests = mock.bins.getRequests(bin.id);
+
+await mock.close(); // also stops the bin cleanup timer
+```
+
+## Configuration
+
+Bins can be disabled or tuned. Limits are passed via the `BinManager`
+constructor and require replacing the default manager:
+
+```javascript
+import { MockHttp, BinManager } from '@jaredwray/mockhttp';
+
+const mock = new MockHttp({
+  httpBin: { bins: true }, // default — set false to disable the routes entirely
+});
+
+// Replace the default manager with custom limits
+mock.bins = new BinManager({
+  defaultTtlMs: 60 * 60 * 1000,   // 1 hour (default: 24h)
+  maxRequestsPerBin: 500,          // (default: 100)
+  maxBodySize: 5 * 1024 * 1024,    // 5 MiB (default: 1 MiB)
+  idLength: 16,                    // (default: 12)
+});
+
+await mock.start();
+```
+
+### Defaults
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `defaultTtlMs` | `86400000` (24h) | Bin lifetime. Expired bins return 404 and are lazily removed. |
+| `maxRequestsPerBin` | `100` | When exceeded, oldest captures are dropped (FIFO). |
+| `maxBodySize` | `1048576` (1 MiB) | Larger bodies are truncated; `truncated: true` is set on the capture. |
+| `idLength` | `12` | Length of generated bin and request ids. |
+| `cleanupIntervalMs` | `60000` (1 min) | How often expired bins are swept. The timer is `unref()`'d so it never keeps the process alive. |
+
+### Pluggable Storage
+
+`BinManager` accepts a `store: BinStore` so you can plug in alternative
+backends (Redis, SQLite, etc.) without changing the rest of the codebase. The
+default `InMemoryBinStore` keeps state in process memory.
+
+```typescript
+import { BinManager, type BinStore } from '@jaredwray/mockhttp';
+
+class MyStore implements BinStore { /* ... */ }
+
+mock.bins = new BinManager({ store: new MyStore() });
+```
+
 # Rate Limiting
 
 MockHttp supports rate limiting using [@fastify/rate-limit](https://github.com/fastify/fastify-rate-limit). Rate limiting is **enabled by default** at **1000 requests per minute** with **localhost (127.0.0.1 and ::1) excluded** from rate limiting.
@@ -654,6 +792,7 @@ new MockHttp(options?)
     - `anything?`: boolean - Enable anything routes (default: true)
     - `auth?`: boolean - Enable authentication routes (default: true)
     - `images?`: boolean - Enable image routes (default: true)
+    - `bins?`: boolean - Enable request bin routes /bins and /b/:id (default: true)
   - `https?`: boolean | HttpsOptions - Enable HTTPS with auto-generated or custom certificates (default: undefined/disabled)
   - `http2?`: boolean - Enable HTTP/2 support (default: false)
   - `http1?`: boolean - Allow HTTP/1.1 fallback when using HTTP/2 with HTTPS (default: true)

--- a/src/bin-manager.ts
+++ b/src/bin-manager.ts
@@ -46,8 +46,12 @@ export class BinManager {
 	constructor(options?: BinManagerOptions) {
 		this._store = options?.store ?? new InMemoryBinStore();
 		this._defaultTtlMs = options?.defaultTtlMs ?? DEFAULT_TTL_MS;
-		this._maxRequestsPerBin =
-			options?.maxRequestsPerBin ?? DEFAULT_MAX_REQUESTS;
+		// Clamp to 0 so a negative cap can't drive the storage layer into a
+		// runaway pop loop.
+		this._maxRequestsPerBin = Math.max(
+			0,
+			options?.maxRequestsPerBin ?? DEFAULT_MAX_REQUESTS,
+		);
 		this._maxBodySize = options?.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
 		this._idLength = options?.idLength ?? DEFAULT_ID_LENGTH;
 		this._cleanupIntervalMs =

--- a/src/bin-manager.ts
+++ b/src/bin-manager.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import {
+	type Bin,
+	type BinStore,
+	type CapturedRequest,
+	InMemoryBinStore,
+} from "./bin-store.js";
+
+/**
+ * Configuration options for {@link BinManager}.
+ */
+export type BinManagerOptions = {
+	/** Storage backend. Defaults to a new {@link InMemoryBinStore}. */
+	store?: BinStore;
+	/** Bin lifetime in milliseconds. Defaults to 24 hours. */
+	defaultTtlMs?: number;
+	/** Maximum number of requests retained per bin (FIFO). Defaults to 100. */
+	maxRequestsPerBin?: number;
+	/** Maximum captured body size in bytes. Larger bodies are truncated. Defaults to 1 MiB. */
+	maxBodySize?: number;
+	/** Length of generated bin and request ids. Defaults to 12. */
+	idLength?: number;
+	/** Interval between cleanup sweeps in milliseconds. Defaults to 1 minute. */
+	cleanupIntervalMs?: number;
+};
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MAX_REQUESTS = 100;
+const DEFAULT_MAX_BODY_SIZE = 1024 * 1024;
+const DEFAULT_ID_LENGTH = 12;
+const DEFAULT_CLEANUP_INTERVAL_MS = 60_000;
+
+/**
+ * Manages request bins: ephemeral URL endpoints that capture incoming HTTP
+ * requests so they can be inspected later.
+ */
+export class BinManager {
+	private readonly _store: BinStore;
+	private readonly _defaultTtlMs: number;
+	private readonly _maxRequestsPerBin: number;
+	private readonly _maxBodySize: number;
+	private readonly _idLength: number;
+	private readonly _cleanupIntervalMs: number;
+	private _cleanupTimer: ReturnType<typeof setInterval> | undefined;
+
+	constructor(options?: BinManagerOptions) {
+		this._store = options?.store ?? new InMemoryBinStore();
+		this._defaultTtlMs = options?.defaultTtlMs ?? DEFAULT_TTL_MS;
+		this._maxRequestsPerBin =
+			options?.maxRequestsPerBin ?? DEFAULT_MAX_REQUESTS;
+		this._maxBodySize = options?.maxBodySize ?? DEFAULT_MAX_BODY_SIZE;
+		this._idLength = options?.idLength ?? DEFAULT_ID_LENGTH;
+		this._cleanupIntervalMs =
+			options?.cleanupIntervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
+	}
+
+	/** Underlying storage backend. */
+	public get store(): BinStore {
+		return this._store;
+	}
+
+	/** Maximum captured body size in bytes. */
+	public get maxBodySize(): number {
+		return this._maxBodySize;
+	}
+
+	/** Maximum number of requests retained per bin. */
+	public get maxRequestsPerBin(): number {
+		return this._maxRequestsPerBin;
+	}
+
+	/** Default bin lifetime in milliseconds. */
+	public get defaultTtlMs(): number {
+		return this._defaultTtlMs;
+	}
+
+	/** Create a new bin with the configured TTL. */
+	public createBin(): Bin {
+		const id = this.generateId();
+		const now = Date.now();
+		const bin: Bin = {
+			id,
+			createdAt: new Date(now).toISOString(),
+			expiresAt: new Date(now + this._defaultTtlMs).toISOString(),
+			requestCount: 0,
+		};
+		this._store.createBin(bin);
+		return bin;
+	}
+
+	/**
+	 * Look up a bin by id. Returns `undefined` if the bin does not exist or
+	 * has expired (in which case it is also lazily removed).
+	 */
+	public getBin(id: string): Bin | undefined {
+		const bin = this._store.getBin(id);
+		if (!bin) {
+			return undefined;
+		}
+		if (Date.parse(bin.expiresAt) <= Date.now()) {
+			this._store.deleteBin(id);
+			return undefined;
+		}
+		return bin;
+	}
+
+	/** List all non-expired bins. */
+	public listBins(): Bin[] {
+		const now = Date.now();
+		const result: Bin[] = [];
+		for (const bin of this._store.listBins()) {
+			if (Date.parse(bin.expiresAt) <= now) {
+				this._store.deleteBin(bin.id);
+				continue;
+			}
+			result.push(bin);
+		}
+		return result;
+	}
+
+	/** Delete a bin. Returns true if the bin existed. */
+	public deleteBin(id: string): boolean {
+		return this._store.deleteBin(id);
+	}
+
+	/**
+	 * Record an incoming request against a bin. Returns the stored
+	 * {@link CapturedRequest}, or `undefined` if the bin does not exist or is
+	 * expired.
+	 */
+	public recordRequest(
+		binId: string,
+		raw: Omit<CapturedRequest, "id" | "binId" | "capturedAt">,
+	): CapturedRequest | undefined {
+		const bin = this.getBin(binId);
+		if (!bin) {
+			return undefined;
+		}
+		const captured: CapturedRequest = {
+			...raw,
+			id: this.generateId(),
+			binId,
+			capturedAt: new Date().toISOString(),
+		};
+		this._store.addRequest(binId, captured, this._maxRequestsPerBin);
+		return captured;
+	}
+
+	/** List captured requests for a bin (newest first). */
+	public getRequests(binId: string): CapturedRequest[] {
+		return this._store.getRequests(binId);
+	}
+
+	/** Look up a single captured request. */
+	public getRequest(binId: string, reqId: string): CapturedRequest | undefined {
+		return this._store.getRequest(binId, reqId);
+	}
+
+	/** Clear all captured requests in a bin. */
+	public clearRequests(binId: string): void {
+		this._store.clearRequests(binId);
+	}
+
+	/** Start the periodic cleanup of expired bins. */
+	public start(): void {
+		if (this._cleanupTimer) {
+			return;
+		}
+		this._cleanupTimer = setInterval(() => {
+			this._store.cleanupExpired(Date.now());
+		}, this._cleanupIntervalMs);
+		this._cleanupTimer.unref();
+	}
+
+	/** Stop the periodic cleanup. Idempotent. */
+	public stop(): void {
+		if (this._cleanupTimer) {
+			clearInterval(this._cleanupTimer);
+			this._cleanupTimer = undefined;
+		}
+	}
+
+	private generateId(): string {
+		return randomUUID().replaceAll("-", "").slice(0, this._idLength);
+	}
+}

--- a/src/bin-store.ts
+++ b/src/bin-store.ts
@@ -1,0 +1,149 @@
+/**
+ * A request captured by a bin, including method, headers, body and metadata.
+ */
+export type CapturedRequest = {
+	/** Unique identifier for this captured request */
+	id: string;
+	/** Identifier of the bin that captured this request */
+	binId: string;
+	/** HTTP method (GET, POST, etc.) */
+	method: string;
+	/** Request URL path + query, relative to the bin (e.g. "/foo?x=1") */
+	url: string;
+	/** Sub-path after the bin id ("/" if the request hit the bin root) */
+	path: string;
+	/** Parsed query string parameters */
+	query: Record<string, string | string[]>;
+	/** Request headers */
+	headers: Record<string, string | string[]>;
+	/** Client IP address as reported by Fastify */
+	remoteAddress: string;
+	/** Content-Type header value, if any */
+	contentType?: string;
+	/** Original body length in bytes */
+	bodySize: number;
+	/** Body payload as utf8 text, base64-encoded bytes, or null when empty */
+	body: string | null;
+	/** Encoding used for the `body` field */
+	bodyEncoding: "utf8" | "base64" | "none";
+	/** True if the body was longer than the configured `maxBodySize` */
+	truncated: boolean;
+	/** ISO timestamp of when the request was captured */
+	capturedAt: string;
+};
+
+/**
+ * Metadata for a bin (without its captured requests).
+ */
+export type Bin = {
+	/** Unique short identifier for the bin */
+	id: string;
+	/** ISO timestamp of bin creation */
+	createdAt: string;
+	/** ISO timestamp at which the bin expires */
+	expiresAt: string;
+	/** Number of requests currently stored in the bin */
+	requestCount: number;
+};
+
+/**
+ * Storage backend for bins and their captured requests. The default
+ * implementation is in-memory; alternative backends (Redis, SQLite, etc.) can
+ * implement this interface without changes to the rest of the codebase.
+ */
+export interface BinStore {
+	/** Create a new bin record. */
+	createBin(bin: Bin): void;
+	/** Look up a bin by id. */
+	getBin(id: string): Bin | undefined;
+	/** Return all bins. */
+	listBins(): Bin[];
+	/** Remove a bin and all its captured requests. Returns true if removed. */
+	deleteBin(id: string): boolean;
+	/**
+	 * Append a captured request to a bin, dropping the oldest if the bin has
+	 * already reached `max` requests (FIFO).
+	 */
+	addRequest(binId: string, req: CapturedRequest, max: number): void;
+	/** List captured requests for a bin (newest first). */
+	getRequests(binId: string): CapturedRequest[];
+	/** Look up a single captured request by id. */
+	getRequest(binId: string, reqId: string): CapturedRequest | undefined;
+	/** Clear all captured requests in a bin (the bin itself is preserved). */
+	clearRequests(binId: string): void;
+	/**
+	 * Remove bins whose `expiresAt` is in the past relative to `now`.
+	 * Returns the ids of bins that were removed.
+	 */
+	cleanupExpired(now: number): string[];
+}
+
+/**
+ * In-memory implementation of {@link BinStore} backed by two Maps. State is
+ * lost when the process exits.
+ */
+export class InMemoryBinStore implements BinStore {
+	private readonly _bins = new Map<string, Bin>();
+	private readonly _requests = new Map<string, CapturedRequest[]>();
+
+	public createBin(bin: Bin): void {
+		this._bins.set(bin.id, bin);
+		this._requests.set(bin.id, []);
+	}
+
+	public getBin(id: string): Bin | undefined {
+		return this._bins.get(id);
+	}
+
+	public listBins(): Bin[] {
+		return [...this._bins.values()];
+	}
+
+	public deleteBin(id: string): boolean {
+		this._requests.delete(id);
+		return this._bins.delete(id);
+	}
+
+	public addRequest(binId: string, req: CapturedRequest, max: number): void {
+		const bin = this._bins.get(binId);
+		const list = this._requests.get(binId);
+		if (!bin || !list) {
+			return;
+		}
+
+		list.unshift(req);
+		while (list.length > max) {
+			list.pop();
+		}
+		bin.requestCount = list.length;
+	}
+
+	public getRequests(binId: string): CapturedRequest[] {
+		return [...(this._requests.get(binId) ?? [])];
+	}
+
+	public getRequest(binId: string, reqId: string): CapturedRequest | undefined {
+		return this._requests.get(binId)?.find((r) => r.id === reqId);
+	}
+
+	public clearRequests(binId: string): void {
+		const bin = this._bins.get(binId);
+		if (!bin) {
+			return;
+		}
+		this._requests.set(binId, []);
+		bin.requestCount = 0;
+	}
+
+	public cleanupExpired(now: number): string[] {
+		const removed: string[] = [];
+		for (const [id, bin] of this._bins) {
+			if (Date.parse(bin.expiresAt) <= now) {
+				this._bins.delete(id);
+				this._requests.delete(id);
+				removed.push(id);
+			}
+		}
+		return removed;
+	}
+}

--- a/src/bin-store.ts
+++ b/src/bin-store.ts
@@ -112,7 +112,9 @@ export class InMemoryBinStore implements BinStore {
 		}
 
 		list.unshift(req);
-		while (list.length > max) {
+		// Guard against negative `max` values: pop only while the list has
+		// something to drop, otherwise we'd spin forever on an empty array.
+		while (list.length > max && list.length > 0) {
 			list.pop();
 		}
 		bin.requestCount = list.length;

--- a/src/fastify-config.ts
+++ b/src/fastify-config.ts
@@ -8,7 +8,14 @@ function isSpecificMatch(
 		return false;
 	}
 	const params = route.params as Record<string, unknown> | undefined;
-	return params === undefined || params["*"] === undefined;
+	// A literal route or one whose params include something other than the
+	// catch-all wildcard is considered specific. `/*` (params keyed only by
+	// "*") is a fallback that should defer to a more specific prefix match.
+	if (!params) {
+		return true;
+	}
+	const keys = Object.keys(params);
+	return keys.length === 0 || keys.some((k) => k !== "*");
 }
 
 export function rewriteUrl(

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,14 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 	await start();
 }
 
+export type { BinManagerOptions } from "./bin-manager.js";
+export { BinManager } from "./bin-manager.js";
+export type {
+	Bin,
+	BinStore,
+	CapturedRequest,
+} from "./bin-store.js";
+export { InMemoryBinStore } from "./bin-store.js";
 export type {
 	CertificateFileOptions,
 	CertificateOptions,

--- a/src/mock-http.ts
+++ b/src/mock-http.ts
@@ -10,6 +10,7 @@ import { fastifySwagger } from "@fastify/swagger";
 import { detect } from "detect-port";
 import Fastify, { type FastifyInstance } from "fastify";
 import { Hookified, type HookifiedOptions } from "hookified";
+import { BinManager } from "./bin-manager.js";
 import { type CertificateOptions, generateCertificate } from "./certificate.js";
 import { getFastifyConfig } from "./fastify-config.js";
 import { anythingRoute } from "./routes/anything/index.js";
@@ -19,6 +20,8 @@ import {
 	digestAuthRoute,
 	hiddenBasicAuthRoute,
 } from "./routes/auth/index.js";
+import { binsCaptureRoute } from "./routes/bins/capture.js";
+import { binsManagementRoute } from "./routes/bins/management.js";
 import {
 	deleteCookieRoute,
 	getCookiesRoute,
@@ -77,6 +80,7 @@ export type HttpBinOptions = {
 	auth?: boolean;
 	images?: boolean;
 	dynamicData?: boolean;
+	bins?: boolean;
 };
 
 export type HttpsOptions = {
@@ -175,6 +179,7 @@ export class MockHttp extends Hookified {
 		auth: true,
 		images: true,
 		dynamicData: true,
+		bins: true,
 	};
 
 	private _rateLimit?: RateLimitPluginOptions = {
@@ -190,6 +195,7 @@ export class MockHttp extends Hookified {
 
 	private _server: FastifyInstance = Fastify();
 	private _taps: TapManager = new TapManager();
+	private _bins: BinManager = new BinManager();
 
 	constructor(options?: MockHttpOptions) {
 		super(options?.hookOptions);
@@ -467,6 +473,20 @@ export class MockHttp extends Hookified {
 	}
 
 	/**
+	 * The BinManager instance for managing request bins.
+	 */
+	public get bins(): BinManager {
+		return this._bins;
+	}
+
+	/**
+	 * The BinManager instance for managing request bins.
+	 */
+	public set bins(bins: BinManager) {
+		this._bins = bins;
+	}
+
+	/**
 	 * Start the Fastify server. If the server is already running, it will be closed and restarted.
 	 */
 	public async start(): Promise<void> {
@@ -587,6 +607,7 @@ export class MockHttp extends Hookified {
 				auth,
 				images,
 				dynamicData,
+				bins,
 			} = this._httpBin;
 
 			if (httpMethods) {
@@ -633,6 +654,11 @@ export class MockHttp extends Hookified {
 				await this.registerDynamicDataRoutes();
 			}
 
+			if (bins) {
+				await this.registerBinRoutes();
+				this._bins.start();
+			}
+
 			if (this._autoDetectPort) {
 				const originalPort = this._port;
 				this._port = await this.detectPort();
@@ -655,6 +681,7 @@ export class MockHttp extends Hookified {
 	 * Close the Fastify server.
 	 */
 	public async close(): Promise<void> {
+		this._bins.stop();
 		await this._server.close();
 	}
 
@@ -825,6 +852,18 @@ export class MockHttp extends Hookified {
 		await fastify.register(rangeRoute);
 		await fastify.register(dripRoute);
 		await fastify.register(linksRoute);
+	}
+
+	/**
+	 * Register the request bin routes (management at /bins and capture at /b/:id).
+	 * @param fastifyInstance - the server instance to register the routes on.
+	 */
+	public async registerBinRoutes(
+		fastifyInstance?: FastifyInstance,
+	): Promise<void> {
+		const fastify = fastifyInstance ?? this._server;
+		await fastify.register(binsManagementRoute(this._bins));
+		await fastify.register(binsCaptureRoute(this._bins));
 	}
 	private async resolveHttpsCredentials(
 		options: HttpsOptions,

--- a/src/routes/bins/capture.ts
+++ b/src/routes/bins/capture.ts
@@ -1,0 +1,148 @@
+import type {
+	FastifyInstance,
+	FastifyReply,
+	FastifyRequest,
+	FastifySchema,
+} from "fastify";
+import type { BinManager } from "../../bin-manager.js";
+
+const captureSchema: FastifySchema = {
+	description:
+		"Capture any HTTP request sent to a bin. Stores method, headers, body, query, and metadata.",
+	tags: ["Bins"],
+	params: {
+		type: "object",
+		properties: {
+			id: { type: "string", description: "Bin identifier" },
+			"*": {
+				type: "string",
+				description: "Sub-path captured with the request",
+			},
+		},
+		required: ["id"],
+	},
+	response: {
+		200: {
+			type: "object",
+			properties: {
+				ok: { type: "boolean" },
+				binId: { type: "string" },
+				requestId: { type: "string" },
+			},
+			required: ["ok", "binId", "requestId"],
+		},
+		404: {
+			type: "object",
+			properties: { error: { type: "string" } },
+			required: ["error"],
+		},
+	},
+};
+
+const TEXT_CONTENT_TYPE_REGEX =
+	/^(text\/|application\/(json|xml|x-www-form-urlencoded|javascript))/i;
+
+type CaptureRequest = FastifyRequest<{
+	Params: { id: string; "*"?: string };
+}>;
+
+/**
+ * Create a Fastify plugin that registers the catch-all bin capture endpoint
+ * at `/b/:id` and `/b/:id/*`, with the provided {@link BinManager} injected.
+ */
+export const binsCaptureRoute = (binManager: BinManager) => {
+	return (fastify: FastifyInstance) => {
+		// Capture every request body as a raw Buffer regardless of content type.
+		// Default Fastify parsers (json, text, urlencoded) would otherwise pre-parse
+		// the payload and we'd lose access to the raw bytes for binary content.
+		fastify.removeAllContentTypeParsers();
+		fastify.addContentTypeParser(
+			"*",
+			{ parseAs: "buffer" },
+			(_request, body, done) => {
+				done(null, body);
+			},
+		);
+
+		const handler = async (request: CaptureRequest, reply: FastifyReply) => {
+			const { id } = request.params;
+			const rest = request.params["*"] ?? "";
+
+			const bin = binManager.getBin(id);
+			if (!bin) {
+				return reply.code(404).send({ error: "bin_not_found" });
+			}
+
+			const raw = request.body as Buffer | undefined;
+			const bodySize = raw?.length ?? 0;
+			const max = binManager.maxBodySize;
+			const truncated = bodySize > max;
+			const slice = raw && raw.length > 0 ? raw.subarray(0, max) : undefined;
+			const contentTypeHeader = request.headers["content-type"];
+			const contentType =
+				typeof contentTypeHeader === "string" ? contentTypeHeader : undefined;
+			const isText = contentType
+				? TEXT_CONTENT_TYPE_REGEX.test(contentType)
+				: false;
+
+			let bodyEncoding: "utf8" | "base64" | "none";
+			let body: string | null;
+			if (!slice) {
+				bodyEncoding = "none";
+				body = null;
+			} else if (isText) {
+				bodyEncoding = "utf8";
+				body = slice.toString("utf8");
+			} else {
+				bodyEncoding = "base64";
+				body = slice.toString("base64");
+			}
+
+			const prefix = `/b/${id}`;
+			const url = request.url.slice(prefix.length) || "/";
+			const path = rest ? `/${rest}` : "/";
+
+			const captured = binManager.recordRequest(id, {
+				method: request.method,
+				url,
+				path,
+				query: request.query as Record<string, string | string[]>,
+				headers: request.headers as Record<string, string | string[]>,
+				remoteAddress: request.ip,
+				contentType,
+				bodySize,
+				body,
+				bodyEncoding,
+				truncated,
+			});
+
+			return reply.code(200).send({
+				ok: true,
+				binId: id,
+				/* v8 ignore next -- @preserve */
+				requestId: captured?.id ?? "",
+			});
+		};
+
+		const opts = {
+			schema: captureSchema,
+			/* v8 ignore next -- @preserve */
+			validatorCompiler: () => () => true,
+		};
+
+		// HEAD is auto-registered by Fastify when GET is declared, and uses the
+		// same handler — so we register every method *except* HEAD.
+		const methods = [
+			"get",
+			"post",
+			"put",
+			"patch",
+			"delete",
+			"options",
+		] as const;
+		for (const m of methods) {
+			fastify[m]("/b/:id", opts, handler);
+			fastify[m]("/b/:id/*", opts, handler);
+		}
+	};
+};

--- a/src/routes/bins/management.ts
+++ b/src/routes/bins/management.ts
@@ -1,0 +1,287 @@
+import type {
+	FastifyInstance,
+	FastifyReply,
+	FastifyRequest,
+	FastifySchema,
+} from "fastify";
+import type { BinManager } from "../../bin-manager.js";
+
+const binSchema = {
+	type: "object",
+	properties: {
+		id: { type: "string" },
+		createdAt: { type: "string" },
+		expiresAt: { type: "string" },
+		requestCount: { type: "integer" },
+	},
+	required: ["id", "createdAt", "expiresAt", "requestCount"],
+};
+
+const capturedRequestSchema = {
+	type: "object",
+	properties: {
+		id: { type: "string" },
+		binId: { type: "string" },
+		method: { type: "string" },
+		url: { type: "string" },
+		path: { type: "string" },
+		query: { type: "object", additionalProperties: true },
+		headers: { type: "object", additionalProperties: true },
+		remoteAddress: { type: "string" },
+		contentType: { type: "string" },
+		bodySize: { type: "integer" },
+		body: { type: ["string", "null"] },
+		bodyEncoding: { type: "string", enum: ["utf8", "base64", "none"] },
+		truncated: { type: "boolean" },
+		capturedAt: { type: "string" },
+	},
+	required: [
+		"id",
+		"binId",
+		"method",
+		"url",
+		"path",
+		"query",
+		"headers",
+		"remoteAddress",
+		"bodySize",
+		"body",
+		"bodyEncoding",
+		"truncated",
+		"capturedAt",
+	],
+};
+
+const createBinSchema: FastifySchema = {
+	description: "Create a new request bin",
+	tags: ["Bins"],
+	response: {
+		200: {
+			type: "object",
+			properties: {
+				id: { type: "string" },
+				url: { type: "string" },
+				createdAt: { type: "string" },
+				expiresAt: { type: "string" },
+				requestCount: { type: "integer" },
+			},
+			required: ["id", "url", "createdAt", "expiresAt", "requestCount"],
+		},
+	},
+};
+
+const listBinsSchema: FastifySchema = {
+	description: "List all active bins",
+	tags: ["Bins"],
+	response: {
+		200: {
+			type: "object",
+			properties: {
+				bins: { type: "array", items: binSchema },
+			},
+			required: ["bins"],
+		},
+	},
+};
+
+const getBinSchema: FastifySchema = {
+	description: "Get metadata for a single bin",
+	tags: ["Bins"],
+	params: {
+		type: "object",
+		properties: { id: { type: "string" } },
+		required: ["id"],
+	},
+	response: {
+		200: binSchema,
+		404: {
+			type: "object",
+			properties: { error: { type: "string" } },
+			required: ["error"],
+		},
+	},
+};
+
+const listRequestsSchema: FastifySchema = {
+	description: "List captured requests for a bin (newest first)",
+	tags: ["Bins"],
+	params: {
+		type: "object",
+		properties: { id: { type: "string" } },
+		required: ["id"],
+	},
+	response: {
+		200: {
+			type: "object",
+			properties: {
+				requests: { type: "array", items: capturedRequestSchema },
+			},
+			required: ["requests"],
+		},
+		404: {
+			type: "object",
+			properties: { error: { type: "string" } },
+			required: ["error"],
+		},
+	},
+};
+
+const getRequestSchema: FastifySchema = {
+	description: "Get a single captured request by id",
+	tags: ["Bins"],
+	params: {
+		type: "object",
+		properties: {
+			id: { type: "string" },
+			reqId: { type: "string" },
+		},
+		required: ["id", "reqId"],
+	},
+	response: {
+		200: capturedRequestSchema,
+		404: {
+			type: "object",
+			properties: { error: { type: "string" } },
+			required: ["error"],
+		},
+	},
+};
+
+const deleteBinSchema: FastifySchema = {
+	description: "Delete a bin and all its captured requests",
+	tags: ["Bins"],
+	params: {
+		type: "object",
+		properties: { id: { type: "string" } },
+		required: ["id"],
+	},
+	response: {
+		204: { type: "null" },
+		404: {
+			type: "object",
+			properties: { error: { type: "string" } },
+			required: ["error"],
+		},
+	},
+};
+
+const clearRequestsSchema: FastifySchema = {
+	description: "Clear all captured requests for a bin",
+	tags: ["Bins"],
+	params: {
+		type: "object",
+		properties: { id: { type: "string" } },
+		required: ["id"],
+	},
+	response: {
+		204: { type: "null" },
+		404: {
+			type: "object",
+			properties: { error: { type: "string" } },
+			required: ["error"],
+		},
+	},
+};
+
+type BinIdRequest = FastifyRequest<{ Params: { id: string } }>;
+type RequestIdRequest = FastifyRequest<{
+	Params: { id: string; reqId: string };
+}>;
+
+/**
+ * Create a Fastify plugin that registers bin management endpoints, with the
+ * provided {@link BinManager} injected.
+ */
+export const binsManagementRoute = (binManager: BinManager) => {
+	return (fastify: FastifyInstance) => {
+		fastify.post(
+			"/bins",
+			{ schema: createBinSchema },
+			async (request: FastifyRequest, _reply: FastifyReply) => {
+				const bin = binManager.createBin();
+				/* v8 ignore next -- @preserve */
+				const host = request.headers.host ?? request.hostname;
+				return {
+					...bin,
+					url: `${request.protocol}://${host}/b/${bin.id}`,
+				};
+			},
+		);
+
+		fastify.get(
+			"/bins",
+			{ schema: listBinsSchema },
+			async (_request, _reply) => ({
+				bins: binManager.listBins(),
+			}),
+		);
+
+		fastify.get(
+			"/bins/:id",
+			{ schema: getBinSchema },
+			async (request: BinIdRequest, reply: FastifyReply) => {
+				const bin = binManager.getBin(request.params.id);
+				if (!bin) {
+					return reply.code(404).send({ error: "bin_not_found" });
+				}
+				return bin;
+			},
+		);
+
+		fastify.get(
+			"/bins/:id/requests",
+			{ schema: listRequestsSchema },
+			async (request: BinIdRequest, reply: FastifyReply) => {
+				const bin = binManager.getBin(request.params.id);
+				if (!bin) {
+					return reply.code(404).send({ error: "bin_not_found" });
+				}
+				return { requests: binManager.getRequests(request.params.id) };
+			},
+		);
+
+		fastify.get(
+			"/bins/:id/requests/:reqId",
+			{ schema: getRequestSchema },
+			async (request: RequestIdRequest, reply: FastifyReply) => {
+				const bin = binManager.getBin(request.params.id);
+				if (!bin) {
+					return reply.code(404).send({ error: "bin_not_found" });
+				}
+				const captured = binManager.getRequest(
+					request.params.id,
+					request.params.reqId,
+				);
+				if (!captured) {
+					return reply.code(404).send({ error: "request_not_found" });
+				}
+				return captured;
+			},
+		);
+
+		fastify.delete(
+			"/bins/:id/requests",
+			{ schema: clearRequestsSchema },
+			async (request: BinIdRequest, reply: FastifyReply) => {
+				const bin = binManager.getBin(request.params.id);
+				if (!bin) {
+					return reply.code(404).send({ error: "bin_not_found" });
+				}
+				binManager.clearRequests(request.params.id);
+				return reply.code(204).send();
+			},
+		);
+
+		fastify.delete(
+			"/bins/:id",
+			{ schema: deleteBinSchema },
+			async (request: BinIdRequest, reply: FastifyReply) => {
+				const existed = binManager.deleteBin(request.params.id);
+				if (!existed) {
+					return reply.code(404).send({ error: "bin_not_found" });
+				}
+				return reply.code(204).send();
+			},
+		);
+	};
+};

--- a/test/bin-manager.test.ts
+++ b/test/bin-manager.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BinManager } from "../src/bin-manager.js";
+import { InMemoryBinStore } from "../src/bin-store.js";
+
+describe("BinManager", () => {
+	let manager: BinManager;
+
+	beforeEach(() => {
+		manager = new BinManager();
+	});
+
+	afterEach(() => {
+		manager.stop();
+		vi.useRealTimers();
+	});
+
+	describe("constructor + defaults", () => {
+		it("uses default options when none provided", () => {
+			expect(manager.maxBodySize).toBe(1024 * 1024);
+			expect(manager.maxRequestsPerBin).toBe(100);
+			expect(manager.defaultTtlMs).toBe(24 * 60 * 60 * 1000);
+			expect(manager.store).toBeInstanceOf(InMemoryBinStore);
+		});
+
+		it("accepts a custom store and option overrides", () => {
+			const store = new InMemoryBinStore();
+			const custom = new BinManager({
+				store,
+				defaultTtlMs: 1000,
+				maxRequestsPerBin: 5,
+				maxBodySize: 32,
+				idLength: 6,
+				cleanupIntervalMs: 50,
+			});
+			expect(custom.store).toBe(store);
+			expect(custom.defaultTtlMs).toBe(1000);
+			expect(custom.maxRequestsPerBin).toBe(5);
+			expect(custom.maxBodySize).toBe(32);
+		});
+	});
+
+	describe("createBin", () => {
+		it("creates a bin with a short id and TTL-based expiresAt", () => {
+			const bin = manager.createBin();
+			expect(bin.id).toHaveLength(12);
+			expect(bin.requestCount).toBe(0);
+			expect(Date.parse(bin.expiresAt)).toBeGreaterThan(
+				Date.parse(bin.createdAt),
+			);
+		});
+
+		it("honours the configured idLength", () => {
+			const custom = new BinManager({ idLength: 8 });
+			expect(custom.createBin().id).toHaveLength(8);
+		});
+	});
+
+	describe("getBin / listBins (lazy expiration)", () => {
+		it("returns the bin while it is alive", () => {
+			const bin = manager.createBin();
+			expect(manager.getBin(bin.id)?.id).toBe(bin.id);
+		});
+
+		it("returns undefined and removes an expired bin", () => {
+			const short = new BinManager({ defaultTtlMs: 1 });
+			const bin = short.createBin();
+			vi.useFakeTimers();
+			vi.setSystemTime(Date.now() + 1000);
+			expect(short.getBin(bin.id)).toBeUndefined();
+			expect(short.listBins()).toEqual([]);
+		});
+
+		it("filters expired bins from listBins and preserves fresh ones", () => {
+			const short = new BinManager({ defaultTtlMs: 1 });
+			const expiring = short.createBin();
+			vi.useFakeTimers();
+			vi.setSystemTime(Date.now() + 1000);
+			const fresh = short.createBin();
+			const ids = short.listBins().map((b) => b.id);
+			expect(ids).toEqual([fresh.id]);
+			expect(ids).not.toContain(expiring.id);
+		});
+
+		it("returns undefined for an unknown bin", () => {
+			expect(manager.getBin("nope")).toBeUndefined();
+		});
+	});
+
+	describe("deleteBin", () => {
+		it("removes a bin and reports whether it existed", () => {
+			const bin = manager.createBin();
+			expect(manager.deleteBin(bin.id)).toBe(true);
+			expect(manager.deleteBin(bin.id)).toBe(false);
+		});
+	});
+
+	describe("recordRequest", () => {
+		it("appends a captured request and assigns an id + capturedAt", () => {
+			const bin = manager.createBin();
+			const captured = manager.recordRequest(bin.id, {
+				method: "GET",
+				url: "/",
+				path: "/",
+				query: {},
+				headers: {},
+				remoteAddress: "127.0.0.1",
+				bodySize: 0,
+				body: null,
+				bodyEncoding: "none",
+				truncated: false,
+			});
+			expect(captured?.id).toBeDefined();
+			expect(captured?.capturedAt).toBeDefined();
+			expect(manager.getRequests(bin.id)).toHaveLength(1);
+		});
+
+		it("returns undefined for an unknown bin", () => {
+			const captured = manager.recordRequest("ghost", {
+				method: "GET",
+				url: "/",
+				path: "/",
+				query: {},
+				headers: {},
+				remoteAddress: "127.0.0.1",
+				bodySize: 0,
+				body: null,
+				bodyEncoding: "none",
+				truncated: false,
+			});
+			expect(captured).toBeUndefined();
+		});
+
+		it("respects maxRequestsPerBin (FIFO drop)", () => {
+			const small = new BinManager({ maxRequestsPerBin: 2 });
+			const bin = small.createBin();
+			for (let i = 0; i < 5; i += 1) {
+				small.recordRequest(bin.id, {
+					method: "POST",
+					url: "/",
+					path: "/",
+					query: {},
+					headers: {},
+					remoteAddress: "127.0.0.1",
+					bodySize: 0,
+					body: null,
+					bodyEncoding: "none",
+					truncated: false,
+				});
+			}
+			expect(small.getRequests(bin.id)).toHaveLength(2);
+		});
+	});
+
+	describe("getRequest / clearRequests", () => {
+		it("looks up a single captured request by id", () => {
+			const bin = manager.createBin();
+			const captured = manager.recordRequest(bin.id, {
+				method: "GET",
+				url: "/",
+				path: "/",
+				query: {},
+				headers: {},
+				remoteAddress: "127.0.0.1",
+				bodySize: 0,
+				body: null,
+				bodyEncoding: "none",
+				truncated: false,
+			});
+			expect(manager.getRequest(bin.id, captured?.id ?? "")?.id).toBe(
+				captured?.id,
+			);
+			expect(manager.getRequest(bin.id, "missing")).toBeUndefined();
+		});
+
+		it("clears all requests in a bin", () => {
+			const bin = manager.createBin();
+			manager.recordRequest(bin.id, {
+				method: "GET",
+				url: "/",
+				path: "/",
+				query: {},
+				headers: {},
+				remoteAddress: "127.0.0.1",
+				bodySize: 0,
+				body: null,
+				bodyEncoding: "none",
+				truncated: false,
+			});
+			manager.clearRequests(bin.id);
+			expect(manager.getRequests(bin.id)).toEqual([]);
+		});
+	});
+
+	describe("start / stop cleanup timer", () => {
+		it("calls cleanupExpired on the configured interval", () => {
+			vi.useFakeTimers();
+			const store = new InMemoryBinStore();
+			const spy = vi.spyOn(store, "cleanupExpired");
+			const m = new BinManager({ store, cleanupIntervalMs: 100 });
+			m.start();
+			vi.advanceTimersByTime(350);
+			expect(spy).toHaveBeenCalledTimes(3);
+			m.stop();
+		});
+
+		it("is idempotent: start twice only schedules one timer", () => {
+			vi.useFakeTimers();
+			const store = new InMemoryBinStore();
+			const spy = vi.spyOn(store, "cleanupExpired");
+			const m = new BinManager({ store, cleanupIntervalMs: 100 });
+			m.start();
+			m.start();
+			vi.advanceTimersByTime(100);
+			expect(spy).toHaveBeenCalledTimes(1);
+			m.stop();
+		});
+
+		it("stop is idempotent and safe to call before start", () => {
+			expect(() => manager.stop()).not.toThrow();
+			manager.start();
+			manager.stop();
+			expect(() => manager.stop()).not.toThrow();
+		});
+	});
+});

--- a/test/bin-manager.test.ts
+++ b/test/bin-manager.test.ts
@@ -22,6 +22,11 @@ describe("BinManager", () => {
 			expect(manager.store).toBeInstanceOf(InMemoryBinStore);
 		});
 
+		it("clamps a negative maxRequestsPerBin to 0", () => {
+			const m = new BinManager({ maxRequestsPerBin: -10 });
+			expect(m.maxRequestsPerBin).toBe(0);
+		});
+
 		it("accepts a custom store and option overrides", () => {
 			const store = new InMemoryBinStore();
 			const custom = new BinManager({

--- a/test/bin-store.test.ts
+++ b/test/bin-store.test.ts
@@ -125,6 +125,16 @@ describe("InMemoryBinStore", () => {
 		expect(store.getRequests("bin1")).toHaveLength(1);
 	});
 
+	it("does not spin forever when max is negative", () => {
+		store.createBin(makeBin());
+		expect(() => {
+			store.addRequest("bin1", makeRequest({ id: "r1" }), -1);
+		}).not.toThrow();
+		// With max < 0, the single request just added gets evicted on the same
+		// call, leaving the bin empty.
+		expect(store.getRequests("bin1")).toEqual([]);
+	});
+
 	it("cleans up expired bins and returns their ids", () => {
 		const now = Date.now();
 		store.createBin(

--- a/test/bin-store.test.ts
+++ b/test/bin-store.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	type Bin,
+	type CapturedRequest,
+	InMemoryBinStore,
+} from "../src/bin-store.js";
+
+function makeBin(overrides: Partial<Bin> = {}): Bin {
+	const now = Date.now();
+	return {
+		id: overrides.id ?? "bin1",
+		createdAt: new Date(now).toISOString(),
+		expiresAt: new Date(now + 60_000).toISOString(),
+		requestCount: 0,
+		...overrides,
+	};
+}
+
+function makeRequest(
+	overrides: Partial<CapturedRequest> = {},
+): CapturedRequest {
+	return {
+		id: overrides.id ?? "r1",
+		binId: overrides.binId ?? "bin1",
+		method: "GET",
+		url: "/",
+		path: "/",
+		query: {},
+		headers: {},
+		remoteAddress: "127.0.0.1",
+		bodySize: 0,
+		body: null,
+		bodyEncoding: "none",
+		truncated: false,
+		capturedAt: new Date().toISOString(),
+		...overrides,
+	};
+}
+
+describe("InMemoryBinStore", () => {
+	let store: InMemoryBinStore;
+
+	beforeEach(() => {
+		store = new InMemoryBinStore();
+	});
+
+	it("creates and retrieves bins", () => {
+		const bin = makeBin();
+		store.createBin(bin);
+		expect(store.getBin("bin1")).toEqual(bin);
+	});
+
+	it("returns undefined for unknown bin", () => {
+		expect(store.getBin("nope")).toBeUndefined();
+	});
+
+	it("lists all bins", () => {
+		store.createBin(makeBin({ id: "a" }));
+		store.createBin(makeBin({ id: "b" }));
+		expect(
+			store
+				.listBins()
+				.map((b) => b.id)
+				.sort(),
+		).toEqual(["a", "b"]);
+	});
+
+	it("deletes bins and reports whether they existed", () => {
+		store.createBin(makeBin({ id: "a" }));
+		expect(store.deleteBin("a")).toBe(true);
+		expect(store.deleteBin("a")).toBe(false);
+		expect(store.getBin("a")).toBeUndefined();
+	});
+
+	it("adds requests newest-first and updates requestCount", () => {
+		store.createBin(makeBin());
+		store.addRequest("bin1", makeRequest({ id: "r1" }), 10);
+		store.addRequest("bin1", makeRequest({ id: "r2" }), 10);
+		const reqs = store.getRequests("bin1");
+		expect(reqs.map((r) => r.id)).toEqual(["r2", "r1"]);
+		expect(store.getBin("bin1")?.requestCount).toBe(2);
+	});
+
+	it("drops oldest request when bin is at capacity (FIFO)", () => {
+		store.createBin(makeBin());
+		store.addRequest("bin1", makeRequest({ id: "r1" }), 2);
+		store.addRequest("bin1", makeRequest({ id: "r2" }), 2);
+		store.addRequest("bin1", makeRequest({ id: "r3" }), 2);
+		const reqs = store.getRequests("bin1");
+		expect(reqs.map((r) => r.id)).toEqual(["r3", "r2"]);
+		expect(store.getBin("bin1")?.requestCount).toBe(2);
+	});
+
+	it("ignores addRequest for unknown bin", () => {
+		store.addRequest("ghost", makeRequest(), 10);
+		expect(store.getRequests("ghost")).toEqual([]);
+	});
+
+	it("looks up a single captured request", () => {
+		store.createBin(makeBin());
+		store.addRequest("bin1", makeRequest({ id: "r1" }), 10);
+		expect(store.getRequest("bin1", "r1")?.id).toBe("r1");
+		expect(store.getRequest("bin1", "missing")).toBeUndefined();
+		expect(store.getRequest("missing-bin", "r1")).toBeUndefined();
+	});
+
+	it("clears requests but keeps the bin", () => {
+		store.createBin(makeBin());
+		store.addRequest("bin1", makeRequest({ id: "r1" }), 10);
+		store.clearRequests("bin1");
+		expect(store.getRequests("bin1")).toEqual([]);
+		expect(store.getBin("bin1")?.requestCount).toBe(0);
+	});
+
+	it("does nothing when clearing requests for unknown bin", () => {
+		store.clearRequests("ghost");
+		expect(store.getRequests("ghost")).toEqual([]);
+	});
+
+	it("returns isolated copies from getRequests", () => {
+		store.createBin(makeBin());
+		store.addRequest("bin1", makeRequest({ id: "r1" }), 10);
+		const reqs = store.getRequests("bin1");
+		reqs.pop();
+		expect(store.getRequests("bin1")).toHaveLength(1);
+	});
+
+	it("cleans up expired bins and returns their ids", () => {
+		const now = Date.now();
+		store.createBin(
+			makeBin({ id: "old", expiresAt: new Date(now - 1).toISOString() }),
+		);
+		store.createBin(
+			makeBin({ id: "fresh", expiresAt: new Date(now + 60_000).toISOString() }),
+		);
+		const removed = store.cleanupExpired(now);
+		expect(removed).toEqual(["old"]);
+		expect(store.getBin("old")).toBeUndefined();
+		expect(store.getBin("fresh")).toBeDefined();
+	});
+});

--- a/test/fastify-config.test.ts
+++ b/test/fastify-config.test.ts
@@ -124,6 +124,33 @@ describe("rewriteUrl", () => {
 		await fastify.close();
 	});
 
+	it("does not strip when an explicit wildcard subroute exists", async () => {
+		const fastify = Fastify({ logger: false, rewriteUrl });
+		fastify.get("/b/:id", async (request) => ({
+			params: request.params,
+			matched: "root",
+		}));
+		fastify.get("/b/:id/*", async (request) => ({
+			params: request.params,
+			matched: "wildcard",
+		}));
+		await fastify.ready();
+
+		const subpath = await fastify.inject({
+			method: "GET",
+			url: "/b/abc/foo/bar",
+		});
+		expect(subpath.json()).toEqual({
+			params: { id: "abc", "*": "foo/bar" },
+			matched: "wildcard",
+		});
+
+		const root = await fastify.inject({ method: "GET", url: "/b/abc" });
+		expect(root.json()).toEqual({ params: { id: "abc" }, matched: "root" });
+
+		await fastify.close();
+	});
+
 	it("prefers a specific route over a wildcard catch-all when stripping", async () => {
 		const fastify = Fastify({ logger: false, rewriteUrl });
 		fastify.get("/status/:code", async () => ({ matched: "status" }));
@@ -156,6 +183,17 @@ describe("rewriteUrl", () => {
 			method: undefined,
 		} as unknown as import("node:http").IncomingMessage);
 		expect(result).toBe("/status/429/foo");
+	});
+
+	it("treats routes with undefined params as specific", () => {
+		const fakeFastify = {
+			findRoute: () => ({ params: undefined }),
+		} as unknown as import("fastify").FastifyInstance;
+		const result = rewriteUrl.call(fakeFastify, {
+			url: "/something/anything",
+			method: "GET",
+		} as unknown as import("node:http").IncomingMessage);
+		expect(result).toBe("/something/anything");
 	});
 
 	it("returns '/' when the request URL is missing", () => {

--- a/test/mock-http.test.ts
+++ b/test/mock-http.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import Fastify from "fastify";
 import { describe, expect, test } from "vitest";
+import { BinManager } from "../src/bin-manager.js";
 import { generateCertificate } from "../src/certificate.js";
 import { MockHttp, type MockHttpOptions, mockhttp } from "../src/mock-http.js";
 import { TapManager } from "../src/tap-manager.js";
@@ -111,6 +112,101 @@ describe("MockHttp", () => {
 		expect(unknown.statusCode).toBe(404);
 
 		await mock.close();
+	});
+
+	describe("request bin feature", () => {
+		test("exposes the BinManager via the bins getter", () => {
+			const mock = new MockHttp();
+			expect(mock.bins).toBeInstanceOf(BinManager);
+		});
+
+		test("allows replacing the BinManager via the bins setter", () => {
+			const mock = new MockHttp();
+			const replacement = new BinManager({ defaultTtlMs: 1000 });
+			mock.bins = replacement;
+			expect(mock.bins).toBe(replacement);
+		});
+
+		test("registers and serves bin routes when enabled", async () => {
+			const mock = new MockHttp({ logging: false });
+			await mock.start();
+
+			const created = await mock.server.inject({
+				method: "POST",
+				url: "/bins",
+			});
+			expect(created.statusCode).toBe(200);
+			const id = created.json().id;
+
+			const captured = await mock.server.inject({
+				method: "POST",
+				url: `/b/${id}/webhook?source=x`,
+				payload: "hello",
+			});
+			expect(captured.statusCode).toBe(200);
+
+			const list = await mock.server.inject({
+				method: "GET",
+				url: `/bins/${id}/requests`,
+			});
+			expect(list.json().requests).toHaveLength(1);
+			expect(list.json().requests[0].path).toBe("/webhook");
+
+			await mock.close();
+		});
+
+		test("skips bin route registration when httpBin.bins is false", async () => {
+			const mock = new MockHttp({
+				logging: false,
+				httpBin: {
+					httpMethods: false,
+					redirects: false,
+					requestInspection: false,
+					responseInspection: false,
+					responseFormats: false,
+					statusCodes: false,
+					cookies: false,
+					anything: false,
+					auth: false,
+					images: false,
+					dynamicData: false,
+					bins: false,
+				},
+			});
+			await mock.start();
+
+			const res = await mock.server.inject({
+				method: "POST",
+				url: "/bins",
+			});
+			expect(res.statusCode).toBe(404);
+
+			await mock.close();
+		});
+
+		test("registerBinRoutes accepts an explicit fastify instance", async () => {
+			const mock = new MockHttp({ logging: false });
+			const other = Fastify();
+			await mock.registerBinRoutes(other);
+
+			const created = await other.inject({
+				method: "POST",
+				url: "/bins",
+			});
+			expect(created.statusCode).toBe(200);
+			expect(created.json().id).toBeDefined();
+
+			mock.bins.stop();
+			await other.close();
+		});
+
+		test("close() stops the bin cleanup timer", async () => {
+			const mock = new MockHttp({ logging: false });
+			await mock.start();
+			await mock.close();
+			// Calling stop again must be safe (idempotent), proving close() already stopped it.
+			expect(() => mock.bins.stop()).not.toThrow();
+		});
 	});
 
 	describe("injection/tap feature", () => {

--- a/test/routes/bins/capture.test.ts
+++ b/test/routes/bins/capture.test.ts
@@ -1,0 +1,158 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BinManager } from "../../../src/bin-manager.js";
+import { binsCaptureRoute } from "../../../src/routes/bins/capture.js";
+import { binsManagementRoute } from "../../../src/routes/bins/management.js";
+
+async function makeServer(manager?: BinManager) {
+	const fastify = Fastify();
+	const m = manager ?? new BinManager();
+	await fastify.register(binsManagementRoute(m));
+	await fastify.register(binsCaptureRoute(m));
+	return { fastify, manager: m };
+}
+
+async function createBin(fastify: FastifyInstance): Promise<string> {
+	const res = await fastify.inject({ method: "POST", url: "/bins" });
+	return res.json().id;
+}
+
+describe("Bin capture route", () => {
+	let fastify: FastifyInstance;
+	let manager: BinManager;
+
+	beforeEach(async () => {
+		const made = await makeServer();
+		fastify = made.fastify;
+		manager = made.manager;
+	});
+
+	afterEach(async () => {
+		manager.stop();
+		await fastify.close();
+	});
+
+	it("returns 404 when sending to a bin that does not exist", async () => {
+		const res = await fastify.inject({ method: "POST", url: "/b/missing" });
+		expect(res.statusCode).toBe(404);
+		expect(res.json().error).toBe("bin_not_found");
+	});
+
+	it("captures a JSON POST and stores utf8 body", async () => {
+		const id = await createBin(fastify);
+		const res = await fastify.inject({
+			method: "POST",
+			url: `/b/${id}`,
+			headers: { "content-type": "application/json" },
+			payload: JSON.stringify({ hello: "world" }),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().ok).toBe(true);
+		expect(res.json().binId).toBe(id);
+
+		const stored = manager.getRequests(id);
+		expect(stored).toHaveLength(1);
+		expect(stored[0].method).toBe("POST");
+		expect(stored[0].bodyEncoding).toBe("utf8");
+		expect(stored[0].body).toBe('{"hello":"world"}');
+		expect(stored[0].contentType).toBe("application/json");
+	});
+
+	it("base64-encodes a binary body", async () => {
+		const id = await createBin(fastify);
+		const bytes = Buffer.from([0, 1, 2, 3, 255]);
+		await fastify.inject({
+			method: "POST",
+			url: `/b/${id}`,
+			headers: { "content-type": "application/octet-stream" },
+			payload: bytes,
+		});
+		const stored = manager.getRequests(id);
+		expect(stored[0].bodyEncoding).toBe("base64");
+		expect(Buffer.from(stored[0].body ?? "", "base64").equals(bytes)).toBe(
+			true,
+		);
+	});
+
+	it("captures requests without a body as encoding 'none'", async () => {
+		const id = await createBin(fastify);
+		await fastify.inject({ method: "GET", url: `/b/${id}` });
+		const stored = manager.getRequests(id);
+		expect(stored[0].bodyEncoding).toBe("none");
+		expect(stored[0].body).toBeNull();
+		expect(stored[0].contentType).toBeUndefined();
+	});
+
+	it("truncates bodies larger than maxBodySize and flags them", async () => {
+		const small = new BinManager({ maxBodySize: 4 });
+		const made = await makeServer(small);
+		try {
+			const id = await createBin(made.fastify);
+			await made.fastify.inject({
+				method: "POST",
+				url: `/b/${id}`,
+				headers: { "content-type": "text/plain" },
+				payload: "abcdefghij",
+			});
+			const stored = small.getRequests(id);
+			expect(stored[0].truncated).toBe(true);
+			expect(stored[0].bodySize).toBe(10);
+			expect(stored[0].body).toBe("abcd");
+		} finally {
+			small.stop();
+			await made.fastify.close();
+		}
+	});
+
+	it("captures the sub-path and query string", async () => {
+		const id = await createBin(fastify);
+		await fastify.inject({
+			method: "POST",
+			url: `/b/${id}/foo/bar?x=1&y=2`,
+		});
+		const stored = manager.getRequests(id);
+		expect(stored[0].path).toBe("/foo/bar");
+		expect(stored[0].url).toBe("/foo/bar?x=1&y=2");
+		expect(stored[0].query).toEqual({ x: "1", y: "2" });
+	});
+
+	it("captures HEAD and OPTIONS too", async () => {
+		const id = await createBin(fastify);
+		await fastify.inject({ method: "HEAD", url: `/b/${id}` });
+		await fastify.inject({ method: "OPTIONS", url: `/b/${id}` });
+		const methods = manager.getRequests(id).map((r) => r.method);
+		expect(methods).toContain("HEAD");
+		expect(methods).toContain("OPTIONS");
+	});
+
+	it("captures PUT, PATCH, DELETE, GET methods", async () => {
+		const id = await createBin(fastify);
+		for (const method of ["GET", "PUT", "PATCH", "DELETE"] as const) {
+			await fastify.inject({ method, url: `/b/${id}` });
+		}
+		const methods = manager.getRequests(id).map((r) => r.method);
+		expect(methods).toEqual(
+			expect.arrayContaining(["GET", "PUT", "PATCH", "DELETE"]),
+		);
+	});
+
+	it("evicts oldest captures when bin reaches the max", async () => {
+		const small = new BinManager({ maxRequestsPerBin: 2 });
+		const made = await makeServer(small);
+		try {
+			const id = await createBin(made.fastify);
+			for (let i = 0; i < 4; i += 1) {
+				await made.fastify.inject({
+					method: "POST",
+					url: `/b/${id}/n${i}`,
+				});
+			}
+			const stored = small.getRequests(id);
+			expect(stored).toHaveLength(2);
+			expect(stored.map((r) => r.path)).toEqual(["/n3", "/n2"]);
+		} finally {
+			small.stop();
+			await made.fastify.close();
+		}
+	});
+});

--- a/test/routes/bins/management.test.ts
+++ b/test/routes/bins/management.test.ts
@@ -1,0 +1,151 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BinManager } from "../../../src/bin-manager.js";
+import { binsCaptureRoute } from "../../../src/routes/bins/capture.js";
+import { binsManagementRoute } from "../../../src/routes/bins/management.js";
+
+describe("Bin management routes", () => {
+	let fastify: FastifyInstance;
+	let manager: BinManager;
+
+	beforeEach(async () => {
+		fastify = Fastify();
+		manager = new BinManager();
+		await fastify.register(binsManagementRoute(manager));
+		await fastify.register(binsCaptureRoute(manager));
+	});
+
+	afterEach(async () => {
+		manager.stop();
+		await fastify.close();
+	});
+
+	it("POST /bins returns id, url, and timestamps", async () => {
+		const res = await fastify.inject({ method: "POST", url: "/bins" });
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body.id).toBeDefined();
+		expect(body.url).toMatch(new RegExp(`/b/${body.id}$`));
+		expect(body.createdAt).toBeDefined();
+		expect(body.expiresAt).toBeDefined();
+		expect(body.requestCount).toBe(0);
+	});
+
+	it("GET /bins lists created bins", async () => {
+		const a = await fastify.inject({ method: "POST", url: "/bins" });
+		const b = await fastify.inject({ method: "POST", url: "/bins" });
+		const res = await fastify.inject({ method: "GET", url: "/bins" });
+		const ids = res.json().bins.map((bin: { id: string }) => bin.id);
+		expect(ids).toContain(a.json().id);
+		expect(ids).toContain(b.json().id);
+	});
+
+	it("GET /bins/:id returns the bin metadata", async () => {
+		const created = await fastify.inject({ method: "POST", url: "/bins" });
+		const id = created.json().id;
+		const res = await fastify.inject({ method: "GET", url: `/bins/${id}` });
+		expect(res.statusCode).toBe(200);
+		expect(res.json().id).toBe(id);
+	});
+
+	it("GET /bins/:id returns 404 for unknown bins", async () => {
+		const res = await fastify.inject({ method: "GET", url: "/bins/nope" });
+		expect(res.statusCode).toBe(404);
+		expect(res.json().error).toBe("bin_not_found");
+	});
+
+	it("GET /bins/:id/requests returns captured requests", async () => {
+		const created = await fastify.inject({ method: "POST", url: "/bins" });
+		const id = created.json().id;
+		await fastify.inject({ method: "POST", url: `/b/${id}`, payload: "hello" });
+		const res = await fastify.inject({
+			method: "GET",
+			url: `/bins/${id}/requests`,
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().requests).toHaveLength(1);
+	});
+
+	it("GET /bins/:id/requests returns 404 for unknown bin", async () => {
+		const res = await fastify.inject({
+			method: "GET",
+			url: "/bins/missing/requests",
+		});
+		expect(res.statusCode).toBe(404);
+	});
+
+	it("GET /bins/:id/requests/:reqId fetches a single capture", async () => {
+		const created = await fastify.inject({ method: "POST", url: "/bins" });
+		const id = created.json().id;
+		await fastify.inject({ method: "POST", url: `/b/${id}` });
+		const list = await fastify.inject({
+			method: "GET",
+			url: `/bins/${id}/requests`,
+		});
+		const reqId = list.json().requests[0].id;
+		const single = await fastify.inject({
+			method: "GET",
+			url: `/bins/${id}/requests/${reqId}`,
+		});
+		expect(single.statusCode).toBe(200);
+		expect(single.json().id).toBe(reqId);
+	});
+
+	it("GET /bins/:id/requests/:reqId returns 404 for missing bin or request", async () => {
+		const noBin = await fastify.inject({
+			method: "GET",
+			url: "/bins/missing/requests/whatever",
+		});
+		expect(noBin.statusCode).toBe(404);
+
+		const created = await fastify.inject({ method: "POST", url: "/bins" });
+		const id = created.json().id;
+		const noReq = await fastify.inject({
+			method: "GET",
+			url: `/bins/${id}/requests/missing`,
+		});
+		expect(noReq.statusCode).toBe(404);
+		expect(noReq.json().error).toBe("request_not_found");
+	});
+
+	it("DELETE /bins/:id/requests clears captured requests", async () => {
+		const created = await fastify.inject({ method: "POST", url: "/bins" });
+		const id = created.json().id;
+		await fastify.inject({ method: "POST", url: `/b/${id}` });
+		const del = await fastify.inject({
+			method: "DELETE",
+			url: `/bins/${id}/requests`,
+		});
+		expect(del.statusCode).toBe(204);
+		const list = await fastify.inject({
+			method: "GET",
+			url: `/bins/${id}/requests`,
+		});
+		expect(list.json().requests).toHaveLength(0);
+	});
+
+	it("DELETE /bins/:id/requests returns 404 for unknown bin", async () => {
+		const res = await fastify.inject({
+			method: "DELETE",
+			url: "/bins/missing/requests",
+		});
+		expect(res.statusCode).toBe(404);
+	});
+
+	it("DELETE /bins/:id deletes a bin", async () => {
+		const created = await fastify.inject({ method: "POST", url: "/bins" });
+		const id = created.json().id;
+		const del = await fastify.inject({ method: "DELETE", url: `/bins/${id}` });
+		expect(del.statusCode).toBe(204);
+		const after = await fastify.inject({ method: "GET", url: `/bins/${id}` });
+		expect(after.statusCode).toBe(404);
+	});
+
+	it("DELETE /bins/:id returns 404 when bin does not exist", async () => {
+		const res = await fastify.inject({
+			method: "DELETE",
+			url: "/bins/missing",
+		});
+		expect(res.statusCode).toBe(404);
+	});
+});


### PR DESCRIPTION
## Summary

Adds [requestbin.net](https://requestbin.net/docs/features/bins)-style request bins to mockhttp. Users mint an ephemeral URL, send arbitrary HTTP requests to it (any method, sub-path, or body), and read back what was received — useful for webhook debugging.

- **Management API** under `/bins/*` — create, list, get, delete bins; list/get/clear captured requests
- **Capture endpoint** at `/b/:id` and `/b/:id/*` records method, headers, query, body (utf8 for text, base64 for binary), IP, content-type, size, and a truncation flag
- **`BinManager`** with a pluggable `BinStore` interface (`InMemoryBinStore` is the default — Redis/SQLite can plug in later without breaking changes). Configurable TTL (24h default), per-bin request cap (100, FIFO drop), and body size cap (1 MiB, truncate + flag).
- Cleanup timer is `unref()`'d and stopped on server `close()` so it can never keep the Node process alive.
- `rewriteUrl` now treats wildcard routes that also have non-wildcard params (like `/b/:id/*`) as specific, so subpath captures don't get rewritten away. Pure catch-all `/*` routes still defer to more specific prefix matches (existing behavior preserved).

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/bins` | Create a new bin |
| GET | `/bins` | List active bins |
| GET | `/bins/:id` | Get bin metadata |
| GET | `/bins/:id/requests` | List captured requests (newest first) |
| GET | `/bins/:id/requests/:reqId` | Get a single captured request |
| DELETE | `/bins/:id/requests` | Clear all captured requests in a bin |
| DELETE | `/bins/:id` | Delete a bin |
| ANY | `/b/:id` and `/b/:id/*` | Capture any request sent to a bin |

## Quick example

```bash
ID=$(curl -s -X POST http://localhost:3000/bins | jq -r .id)
curl -X POST "http://localhost:3000/b/$ID/webhook?source=stripe" \
  -H 'content-type: application/json' \
  -d '{"event":"payment.succeeded"}'
curl http://localhost:3000/bins/$ID/requests | jq
```

## Test plan

- [x] `pnpm test` — 463 tests pass, lint clean
- [x] New files have 100% coverage; overall coverage unchanged from baseline (99.73%)
- [x] Smoke-tested via curl: bin create, JSON POST capture, binary PUT capture (round-trips through base64), HEAD capture, sub-path + query capture, list, get single, delete bin → 404
- [x] Swagger UI at `/docs` shows the new `Bins` tag with all seven management endpoints plus the capture route
- [x] Existing `rewriteUrl` test "prefers a specific route over a wildcard catch-all" still passes — pure `/*` fallback semantics preserved

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz4hsZ2VC9yUadapN8s58K)_