### PR TITLE
root - chore: upgrade @fastify/rate-limit (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 	"dependencies": {
 		"@fastify/cookie": "^11.0.2",
 		"@fastify/helmet": "^13.0.2",
-		"@fastify/rate-limit": "^10.3.0",
+		"@fastify/rate-limit": "^11.0.0",
 		"@fastify/static": "^9.1.3",
 		"@fastify/swagger": "^9.7.0",
 		"@fastify/swagger-ui": "^5.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: ^13.0.2
         version: 13.0.2
       '@fastify/rate-limit':
-        specifier: ^10.3.0
-        version: 10.3.0
+        specifier: ^11.0.0
+        version: 11.0.0
       '@fastify/static':
         specifier: ^9.1.3
         version: 9.1.3
@@ -613,8 +613,8 @@ packages:
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
-  '@fastify/rate-limit@10.3.0':
-    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
+  '@fastify/rate-limit@11.0.0':
+    resolution: {integrity: sha512-kCs+G59SitZw9TL/ekFe+MrzXk20dEp6zPAM8WEZjFl5Ubvv5ksTbEXYr4jGlBwWAKn78q+NFsj5CN75zXLjaw==}
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
@@ -3429,10 +3429,10 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
 
-  '@fastify/rate-limit@10.3.0':
+  '@fastify/rate-limit@11.0.0':
     dependencies:
       '@lukeed/ms': 2.0.2
-      fastify-plugin: 5.0.1
+      fastify-plugin: 5.1.0
       toad-cache: 3.7.0
 
   '@fastify/send@4.1.0':
@@ -5861,7 +5861,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   super-regex@1.1.0:
@@ -6101,7 +6101,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.9
       rollup: 4.60.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.12.2
       fsevents: 2.3.3


### PR DESCRIPTION
## Summary
Upgrade `@fastify/rate-limit` to v11 (first of the fastify-ecosystem majors).

## Versions
- `@fastify/rate-limit` 10.3.0 → 11.0.0

## Tests
- [x] `pnpm test` passes (473 tests, 100% line coverage)
- [x] `pnpm build` passes (type-checked dts)

## Breaking notes
v11's only breaking change is the removal of some deprecated types. mockhttp uses the plugin via `RateLimitPluginOptions` with `max` / `timeWindow` / `allowList` — none of which were deprecated — so no code changes were required; the type-checked build confirms this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTFTCYyRMHJ3QedmwMaAei)_