### PR TITLE
root - chore: upgrade @fastify/swagger-ui (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"@fastify/rate-limit": "^11.0.0",
 		"@fastify/static": "^9.1.3",
 		"@fastify/swagger": "^9.7.0",
-		"@fastify/swagger-ui": "^5.2.6",
+		"@fastify/swagger-ui": "^6.0.0",
 		"@scalar/api-reference": "^1.55.3",
 		"detect-port": "^2.1.0",
 		"fastify": "^5.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^9.7.0
         version: 9.7.0
       '@fastify/swagger-ui':
-        specifier: ^5.2.6
-        version: 5.2.6
+        specifier: ^6.0.0
+        version: 6.0.0
       '@scalar/api-reference':
         specifier: ^1.55.3
         version: 1.55.3(@vue/compiler-sfc@3.5.32)(tailwindcss@3.4.16)(typescript@6.0.3)
@@ -622,8 +622,8 @@ packages:
   '@fastify/static@9.1.3':
     resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
 
-  '@fastify/swagger-ui@5.2.6':
-    resolution: {integrity: sha512-OMnms0O5s9wb6wis/K5nlrAMLsgUbr1GA8uphM41IasWe3AFdgxz6r/3bA9HTxlDNUYc2FGGKeqMp3ntxmSiNA==}
+  '@fastify/swagger-ui@6.0.0':
+    resolution: {integrity: sha512-L9c4CbXj3FnquqpCmn0IfbEeIqDUNi6QwXd23VhQj/bHEjNzDFIAy2W9I3prvSqM+mJWOElIa6uXROmcMDnfUA==}
 
   '@fastify/swagger@9.7.0':
     resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
@@ -3452,7 +3452,7 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@fastify/swagger-ui@5.2.6':
+  '@fastify/swagger-ui@6.0.0':
     dependencies:
       '@fastify/static': 9.1.3
       fastify-plugin: 5.1.0


### PR DESCRIPTION
## Summary
Upgrade `@fastify/swagger-ui` to v6 (second fastify-ecosystem major; independent of `@fastify/rate-limit`, so a separate PR).

## Versions
- `@fastify/swagger-ui` 5.2.6 → 6.0.0

## Tests
- [x] `pnpm test` passes (473 tests, 100% line coverage)
- [x] `pnpm build` passes (type-checked dts)

## Breaking notes
v6's only breaking change is removal of the deprecated `useUnsafeMarkdown` option, plus an internal type-test tooling refactor. mockhttp's config (`routePrefix`, `uiConfig`, `uiHooks`, `staticCSP`, `transformSpecification`, `transformSpecificationClone`) doesn't use `useUnsafeMarkdown`, so no code changes were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTFTCYyRMHJ3QedmwMaAei)_