### PR TITLE
release: v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jaredwray/mockhttp",
-	"version": "1.6.1",
+	"version": "1.8.0",
 	"description": "Mock Http - Easy way to mock http with httpbin replacement",
 	"type": "module",
 	"main": "dist/index.mjs",


### PR DESCRIPTION
## Release summary
Add request bins for capturing and inspecting HTTP requests; refresh runtime and build dependencies.

> **Version note:** the semver-correct bump from the last shipped release (`1.6.1`) is `1.7.0` (one `feat:`), but a phantom `v1.7.0` tag/GitHub Release already exists — it is actually the `1.6.1` release, mislabeled (its body reads `@jaredwray/mockhttp@1.6.1` and `package.json` at that tag is `1.6.1`). To avoid a tag collision, this cut **skips 1.7.0 and ships 1.8.0**. npm goes `1.6.1 → 1.8.0`.

## @jaredwray/mockhttp@1.8.0 — 2026-06-18

Add request bins for capturing and inspecting HTTP requests; refresh runtime and build dependencies.

### Features
- add request bins for inspecting captured HTTP requests (`41e3d20`, #150)

  Mint an ephemeral URL, send arbitrary requests to it, and read back what was captured — useful for webhook debugging.

  ```bash
  # Create a bin, send a request to it, then inspect what was captured
  ID=$(curl -s -X POST http://localhost:3000/bins | jq -r .id)
  curl -X POST "http://localhost:3000/b/$ID/webhook?source=stripe" \
    -H 'content-type: application/json' \
    -d '{"event":"payment.succeeded"}'
  curl "http://localhost:3000/bins/$ID/requests" | jq
  ```

### Documentation
- expand Request Bins section with end-to-end examples and API reference (`c860005`, #150)

### Internal
- cover MockHttp bin integration; harden against negative `maxRequestsPerBin` (`d6356c1`, #150)
- run deploy-site `test` and `build` in parallel, gate deploy on both (`133115d`, #149)
- upgrade hookified 2.2.0 → 3.0.0 (`58e0717`, #157)
- upgrade @scalar/api-reference 1.55.3 → 1.59.3 (`1209de0`, #156)
- upgrade @fastify/swagger-ui 5.2.6 → 6.0.0 (`b37285c`, #155)
- upgrade @fastify/rate-limit 10.3.0 → 11.0.0 (`3c7e14a`, #154)
- upgrade GitHub Actions — checkout v7, codecov-action v7 (`318c34a`, #153)
- upgrade TypeScript and build tooling — @swc/core, tsx, tsdown (`c474f8d`, #152)
- upgrade code quality dependencies — biome, vitest (`b06c1e6`, #151)

### Contributors
- @jaredwray (11)

### Full List of Changes
- ci(deploy-site): run test and build in parallel by @jaredwray in #149
- feat: add request bins for inspecting captured HTTP requests by @jaredwray in #150
- root - chore: upgrade code quality dependencies by @jaredwray in #151
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #152
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #153
- root - chore: upgrade @fastify/rate-limit (breaking) by @jaredwray in #154
- root - chore: upgrade @fastify/swagger-ui (breaking) by @jaredwray in #155
- root - chore: upgrade @scalar/api-reference by @jaredwray in #156
- root - chore: upgrade hookified (breaking) by @jaredwray in #157

**Full diff:** https://github.com/jaredwray/mockhttp/compare/v1.7.0...v1.8.0

> Note: the `v1.7.0...v1.8.0` diff is correct here because the phantom `v1.7.0` tag points at the `1.6.1` release commit (this release's true anchor).

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds (tsdown 0.22.2, target node22.18.0)
- [x] `pnpm test:ci` passes (100% line coverage, 99.91% statements)
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge then create a GitHub Release at tag `v1.8.0` — the `release.yaml` workflow publishes to npm on the `release: released` event (and `docker-publish.yaml` / `deploy-site.yaml` also fire on that event).

**Recommended cleanup (separate from this PR):** rename/retarget the mislabeled `v1.7.0` GitHub Release + tag to `v1.6.1` so the release history and `compare` links are accurate. This is not required to ship 1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019h8RzTfhcVzLrfLbnY1zeB

---
_Generated by [Claude Code](https://claude.ai/code/session_019h8RzTfhcVzLrfLbnY1zeB)_