### PR TITLE
ci(release): publish to npm via OIDC trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,41 +14,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           package-manager-cache: false
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:ci
 
-  build:
-    name: Build
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          package-manager-cache: false
-      - run: corepack enable
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: dist/
-          if-no-files-found: error
-          retention-days: 1
-
   publish:
     name: Publish to npm
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -56,12 +41,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
-      - uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist/
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
 
       - name: Publish
-        run: npm publish --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --provenance --no-git-checks --ignore-scripts


### PR DESCRIPTION
## Summary

Modernizes `.github/workflows/release.yaml` to publish to npm using **OIDC trusted publishing** with **provenance**, removing the long-lived `NPM_TOKEN` secret and switching the workflow to pnpm end-to-end.

## Changes

- **OIDC + provenance** — The `publish` job now requests `id-token: write` and publishes with `pnpm publish --provenance`. npm authenticates the publish via short-lived OIDC credentials and generates a signed provenance attestation. No token is exchanged or stored.
- **Removed `NPM_TOKEN`** — Dropped the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env entirely; it is no longer needed under trusted publishing.
- **pnpm via `pnpm/action-setup`** — Replaced every `corepack enable` step with `pnpm/action-setup@v6`, which picks up the pinned `pnpm@11.1.3` from the `packageManager` field in `package.json`.
- **Removed artifact plumbing** — Deleted the standalone `build` job plus the `upload-artifact`/`download-artifact` steps. The `publish` job now builds (`pnpm build`) and publishes directly.
- **pnpm only** — `npm publish` → `pnpm publish` (with `--no-git-checks` for the detached-HEAD release checkout and `--ignore-scripts` since the build already ran explicitly).

## Follow-up required (one-time, by maintainer)

For OIDC to work, the package must have a **trusted publisher** configured on npmjs.com:

1. Go to the `@jaredwray/mockhttp` package settings on npmjs.com → **Trusted Publishers**.
2. Add a GitHub Actions publisher: owner `jaredwray`, repo `mockhttp`, workflow `release.yaml`, environment `npm` (the job keeps `environment: npm`).

Until that is configured, the publish step will fail to authenticate. Trusted publishing also requires public-repo publishing for provenance (this repo is public) and cloud-hosted runners (using `ubuntu-latest`).

## Notes

- The user request referenced `pnpm/setup-action`; the canonical action is **`pnpm/action-setup`** (latest major `v6`), which is what's used here.
- pnpm OIDC publishing had a regression in `11.0.8` (pnpm#11513) that was fixed before `11.1.3`, the version pinned in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zRapVaTvAomi5mhczhmCT

---
_Generated by [Claude Code](https://claude.ai/code/session_014zRapVaTvAomi5mhczhmCT)_