### PR TITLE
feat: handle OPTIONS on /anything

### DIFF
--- a/src/routes/anything/index.ts
+++ b/src/routes/anything/index.ts
@@ -108,4 +108,9 @@ export const anythingRoute = (fastify: FastifyInstance) => {
 	fastify.put("/anything", noValidation, handler);
 	fastify.patch("/anything", noValidation, handler);
 	fastify.delete("/anything", noValidation, handler);
+	// OPTIONS goes through the same echo handler as every other method here,
+	// consistent with how the /b/:id bin-capture route already treats OPTIONS
+	// as just another method to record and echo back rather than a bare
+	// CORS-style 204 - "anything" means anything.
+	fastify.options("/anything", noValidation, handler);
 };

--- a/test/routes/anything/index.test.ts
+++ b/test/routes/anything/index.test.ts
@@ -23,4 +23,15 @@ describe("Status Codes Route", () => {
 		expect(response.json().json).toEqual({});
 		expect(response.json().origin).toBeDefined();
 	});
+
+	it("should handle OPTIONS the same as any other method", async () => {
+		const response = await fastify.inject({
+			method: "OPTIONS",
+			url: "/anything",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().method).toBe("OPTIONS");
+		expect(response.json().url).toBe("/anything");
+	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/mockhttp/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/jaredwray/mockhttp/blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Feature — `/anything` now handles `OPTIONS` like every other method instead of 404ing.

---

## Summary

`/anything` currently registers GET/POST/PUT/PATCH/DELETE but not OPTIONS, so an OPTIONS request to it 404s instead of being echoed back like every other method:

```
$ curl -s -o /dev/null -w "%{http_code}\n" -X OPTIONS http://127.0.0.1:3000/anything
404
```

I ran into this migrating a project's GM_xmlhttpRequest test suite onto mockhttp.org — a test exercising `OPTIONS` against `/anything` (the closest equivalent to httpbin/httpbun, which commonly return 200 for OPTIONS) got a 404 instead.

## Fix

Registers `fastify.options("/anything", ...)` alongside the other methods, running through the exact same echo handler rather than special-casing it as a bare CORS-style 204. This mirrors the precedent already set by the `/b/:id` bin-capture route (`src/routes/bins/capture.ts`), which explicitly loops over `["get", "post", "put", "patch", "delete", "options"]` and treats OPTIONS as just another method to record and echo — since "anything" is meant to accept anything, including a preflight-shaped request.

## Test plan
- [x] Added a test asserting `OPTIONS /anything` returns 200 with `method: "OPTIONS"` in the echoed body.
- [x] `pnpm test` (lint + full vitest run with coverage) passes locally: 474 tests, 100% line coverage, no lint warnings.
- [x] Manually verified against a local `tsx src/index.ts` instance.
