### PR TITLE
feat: accept raw/binary request bodies on /post and /anything

### DIFF
--- a/src/routes/anything/index.ts
+++ b/src/routes/anything/index.ts
@@ -6,6 +6,8 @@ import type {
 } from "fastify";
 import {
 	encodeRequestBody,
+	isFormContentType,
+	isJsonContentType,
 	registerRawBodyFallbackParser,
 } from "../http-methods/raw-body.js";
 
@@ -82,16 +84,19 @@ export const anythingRoute = (fastify: FastifyInstance) => {
 	registerRawBodyFallbackParser(fastify);
 
 	const handler = async (request: FastifyRequest, reply: FastifyReply) => {
-		const body =
-			encodeRequestBody(request.body, request.headers["content-type"]) ?? {};
+		const contentType = request.headers["content-type"];
+		const body = encodeRequestBody(request.body, contentType) ?? {};
 		const response: AnythingResponse = {
 			args: request.query as Record<string, unknown>,
 			data: body,
 			// biome-ignore lint/suspicious/noExplicitAny: expected
 			files: (request.raw as any)?.files ?? {},
-			form: body,
+			// Only mirror the body into `form`/`json` when the Content-Type
+			// actually says so, so a binary/raw payload doesn't show up under
+			// a field that implies it was parsed as something it wasn't.
+			form: isFormContentType(contentType) ? body : {},
 			headers: request.headers,
-			json: body,
+			json: isJsonContentType(contentType) ? body : {},
 			method: request.method,
 			origin: request.headers.origin ?? request.headers.host ?? "",
 			url: request.url,

--- a/src/routes/anything/index.ts
+++ b/src/routes/anything/index.ts
@@ -4,6 +4,10 @@ import type {
 	FastifyRequest,
 	FastifySchema,
 } from "fastify";
+import {
+	encodeRequestBody,
+	registerRawBodyFallbackParser,
+} from "../http-methods/raw-body.js";
 
 const anythingSchema: FastifySchema = {
 	description: "Will return anything that you send it",
@@ -19,11 +23,11 @@ const anythingSchema: FastifySchema = {
 					additionalProperties: true,
 				},
 
-				// Echo back whatever was in the request.body
+				// Echo back whatever was in the request.body. Any valid JSON
+				// value, or the utf8/base64 string produced for non-JSON
+				// content types - see raw-body.ts.
 				data: {
-					type: "object",
 					description: "Request body data",
-					additionalProperties: true,
 				},
 
 				// If you’re using fastify-multipart, you’ll get
@@ -39,9 +43,7 @@ const anythingSchema: FastifySchema = {
 				// these fields land in request.body too, but you can
 				// mirror them separately if you like
 				form: {
-					type: "object",
 					description: "Form data",
-					additionalProperties: true,
 				},
 
 				headers: {
@@ -51,9 +53,7 @@ const anythingSchema: FastifySchema = {
 				},
 
 				json: {
-					type: "object",
 					description: "Parsed JSON body",
-					additionalProperties: true,
 				},
 
 				method: { type: "string", description: "HTTP method used" },
@@ -68,26 +68,30 @@ const anythingSchema: FastifySchema = {
 
 export type AnythingResponse = {
 	args: Record<string, unknown>;
-	data: Record<string, unknown>;
+	data: unknown;
 	files: Record<string, unknown>;
-	form: Record<string, unknown>;
+	form: unknown;
 	headers: Record<string, unknown>;
-	json: Record<string, unknown>;
+	json: unknown;
 	method: string;
 	origin: string;
 	url: string;
 };
 
 export const anythingRoute = (fastify: FastifyInstance) => {
+	registerRawBodyFallbackParser(fastify);
+
 	const handler = async (request: FastifyRequest, reply: FastifyReply) => {
+		const body =
+			encodeRequestBody(request.body, request.headers["content-type"]) ?? {};
 		const response: AnythingResponse = {
 			args: request.query as Record<string, unknown>,
-			data: (request.body as Record<string, unknown>) ?? {},
+			data: body,
 			// biome-ignore lint/suspicious/noExplicitAny: expected
 			files: (request.raw as any)?.files ?? {},
-			form: (request.body as Record<string, unknown>) ?? {},
+			form: body,
 			headers: request.headers,
-			json: (request.body as Record<string, unknown>) ?? {},
+			json: body,
 			method: request.method,
 			origin: request.headers.origin ?? request.headers.host ?? "",
 			url: request.url,

--- a/src/routes/http-methods/post.ts
+++ b/src/routes/http-methods/post.ts
@@ -1,20 +1,22 @@
 import type { FastifyInstance, FastifyRequest, FastifySchema } from "fastify";
+import {
+	encodeRequestBody,
+	registerRawBodyFallbackParser,
+} from "./raw-body.js";
 
 const postSchema: FastifySchema = {
 	description: "Handles a POST request and returns request information",
 	tags: ["HTTP Methods"],
-	body: {
-		type: "object",
-		additionalProperties: true,
-		description: "The body of the POST request",
-	},
 	response: {
 		200: {
 			type: "object",
 			properties: {
 				method: { type: "string" },
 				headers: { type: "object", additionalProperties: { type: "string" } },
-				body: { type: "object", additionalProperties: true },
+				// Any valid JSON body shape (object, array, string, number,
+				// boolean, null) plus the utf8/base64 string produced for
+				// non-JSON content types - see raw-body.ts.
+				body: {},
 			},
 			required: ["method", "headers", "body"],
 		},
@@ -22,13 +24,19 @@ const postSchema: FastifySchema = {
 };
 
 export const postRoute = (fastify: FastifyInstance) => {
+	registerRawBodyFallbackParser(fastify);
+
 	fastify.post(
 		"/post",
 		{ schema: postSchema },
 		async (request: FastifyRequest) => ({
 			method: "POST",
 			headers: request.headers,
-			body: request.body,
+			// A request with no body at all (no Content-Type, nothing for any
+			// parser to run on) leaves request.body as undefined; fall back to
+			// {} so the required "body" response field is never missing.
+			body:
+				encodeRequestBody(request.body, request.headers["content-type"]) ?? {},
 		}),
 	);
 };

--- a/src/routes/http-methods/raw-body.ts
+++ b/src/routes/http-methods/raw-body.ts
@@ -1,0 +1,51 @@
+import type { FastifyInstance } from "fastify";
+
+const TEXT_CONTENT_TYPE_REGEX =
+	/^(text\/|application\/(json|xml|x-www-form-urlencoded|javascript))/i;
+
+/**
+ * Registers a catch-all content-type parser, scoped to whichever plugin
+ * instance it's called on, that captures any request body Fastify's
+ * built-in parsers don't already handle (json, text/plain) as a raw Buffer
+ * instead of rejecting it with 415 Unsupported Media Type.
+ *
+ * Because `fastify.addContentTypeParser` only tries a "*" parser once no
+ * more specific one matches, this doesn't change how already-handled
+ * content types (e.g. application/json) are parsed - it only fills in the
+ * gap for everything else (application/octet-stream, image/*,
+ * multipart/form-data, missing Content-Type, etc).
+ */
+export function registerRawBodyFallbackParser(fastify: FastifyInstance) {
+	fastify.addContentTypeParser(
+		"*",
+		{ parseAs: "buffer" },
+		(_request, body, done) => {
+			done(null, body);
+		},
+	);
+}
+
+/**
+ * Converts a parsed request body into the value this server echoes back to
+ * clients. Objects/strings (already produced by Fastify's json/text/
+ * urlencoded parsers) pass straight through; a raw Buffer (from
+ * {@link registerRawBodyFallbackParser}) is decoded as utf8 text for
+ * textual content types, or base64 otherwise - the same rule
+ * `src/routes/bins/capture.ts` already uses for its request-bin bodies.
+ */
+export function encodeRequestBody(
+	body: unknown,
+	contentType: string | undefined,
+): unknown {
+	if (!Buffer.isBuffer(body)) {
+		return body;
+	}
+	if (body.length === 0) {
+		return "";
+	}
+
+	const isText = contentType
+		? TEXT_CONTENT_TYPE_REGEX.test(contentType)
+		: false;
+	return isText ? body.toString("utf8") : body.toString("base64");
+}

--- a/src/routes/http-methods/raw-body.ts
+++ b/src/routes/http-methods/raw-body.ts
@@ -1,7 +1,13 @@
 import type { FastifyInstance } from "fastify";
 
+// Matches text/*, the common textual application/* types, and any type using
+// a structured syntax suffix (RFC 6839) like application/ld+json,
+// application/vnd.api+json, or image/svg+xml - those are textual regardless
+// of which top-level media type they hang off of. The trailing \b keeps
+// lookalikes like application/jsonp from matching just because they share a
+// "json"/"xml" prefix.
 const TEXT_CONTENT_TYPE_REGEX =
-	/^(text\/|application\/(json|xml|x-www-form-urlencoded|javascript))/i;
+	/^(text\/|application\/(json|xml|x-www-form-urlencoded|javascript)|[\w.-]+\/[\w.-]*\+(json|xml))\b/i;
 
 /**
  * Registers a catch-all content-type parser, scoped to whichever plugin
@@ -48,4 +54,20 @@ export function encodeRequestBody(
 		? TEXT_CONTENT_TYPE_REGEX.test(contentType)
 		: false;
 	return isText ? body.toString("utf8") : body.toString("base64");
+}
+
+const JSON_CONTENT_TYPE_REGEX = /^application\/(?:[\w.-]*\+)?json\b/i;
+const FORM_CONTENT_TYPE_REGEX =
+	/^(application\/x-www-form-urlencoded|multipart\/form-data)\b/i;
+
+/** Whether a Content-Type header denotes a JSON body (including structured
+ * syntax suffixes like application/ld+json). */
+export function isJsonContentType(contentType: string | undefined): boolean {
+	return contentType != null && JSON_CONTENT_TYPE_REGEX.test(contentType);
+}
+
+/** Whether a Content-Type header denotes a form body (url-encoded or
+ * multipart). */
+export function isFormContentType(contentType: string | undefined): boolean {
+	return contentType != null && FORM_CONTENT_TYPE_REGEX.test(contentType);
 }

--- a/test/routes/anything/index.test.ts
+++ b/test/routes/anything/index.test.ts
@@ -23,4 +23,20 @@ describe("Status Codes Route", () => {
 		expect(response.json().json).toEqual({});
 		expect(response.json().origin).toBeDefined();
 	});
+
+	it("should accept a binary body instead of rejecting it with 415", async () => {
+		const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/anything",
+			payload: png,
+			headers: { "content-type": "image/png" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.data).toBe(png.toString("base64"));
+		expect(body.form).toBe(png.toString("base64"));
+		expect(body.json).toBe(png.toString("base64"));
+	});
 });

--- a/test/routes/anything/index.test.ts
+++ b/test/routes/anything/index.test.ts
@@ -35,8 +35,42 @@ describe("Status Codes Route", () => {
 
 		expect(response.statusCode).toBe(200);
 		const body = response.json();
+		// `data` always carries the encoded body, but a binary payload isn't a
+		// form or a JSON body, so `form`/`json` must not echo it too.
 		expect(body.data).toBe(png.toString("base64"));
-		expect(body.form).toBe(png.toString("base64"));
-		expect(body.json).toBe(png.toString("base64"));
+		expect(body.form).toEqual({});
+		expect(body.json).toEqual({});
+	});
+
+	it("should only populate `form` for a form-urlencoded body", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/anything",
+			payload: "a=1&b=two",
+			headers: { "content-type": "application/x-www-form-urlencoded" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		// This server doesn't register a dedicated application/x-www-form-urlencoded
+		// parser (that's a separate, independent change), so the raw-body
+		// fallback parser here decodes it as text rather than an object - but
+		// it must still land under `form`, not `json`.
+		expect(body.form).toBe("a=1&b=two");
+		expect(body.json).toEqual({});
+	});
+
+	it("should only populate `json` for a JSON body", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/anything",
+			payload: { a: 1 },
+			headers: { "content-type": "application/json" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.json).toEqual({ a: 1 });
+		expect(body.form).toEqual({});
 	});
 });

--- a/test/routes/http-methods/post.test.ts
+++ b/test/routes/http-methods/post.test.ts
@@ -68,4 +68,39 @@ describe("POST /post route", async () => {
 		);
 		expect(responseBody.headers).toHaveProperty("custom-header", "CustomValue");
 	});
+
+	it("should accept a binary body instead of rejecting it with 415", async () => {
+		const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/post",
+			payload: png,
+			headers: { "content-type": "image/png" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().body).toBe(png.toString("base64"));
+	});
+
+	it("should accept a plain-text body and echo it back decoded", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/post",
+			payload: "hello world",
+			headers: { "content-type": "text/plain" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().body).toBe("hello world");
+	});
+
+	it("should return 200 with an empty body instead of crashing when no body is sent at all", async () => {
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/post",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().body).toEqual({});
+	});
 });

--- a/test/routes/http-methods/raw-body.test.ts
+++ b/test/routes/http-methods/raw-body.test.ts
@@ -2,6 +2,8 @@ import Fastify from "fastify";
 import { describe, expect, it } from "vitest";
 import {
 	encodeRequestBody,
+	isFormContentType,
+	isJsonContentType,
 	registerRawBodyFallbackParser,
 } from "../../../src/routes/http-methods/raw-body.js";
 
@@ -73,5 +75,52 @@ describe("encodeRequestBody", () => {
 		expect(encodeRequestBody(Buffer.alloc(0), "application/octet-stream")).toBe(
 			"",
 		);
+	});
+
+	it("decodes structured-syntax-suffix content types (RFC 6839) as text", () => {
+		expect(
+			encodeRequestBody(Buffer.from('{"a":1}'), "application/ld+json"),
+		).toBe('{"a":1}');
+		expect(
+			encodeRequestBody(Buffer.from("<a/>"), "application/vnd.api+json"),
+		).toBe("<a/>");
+		expect(encodeRequestBody(Buffer.from("<a/>"), "image/svg+xml")).toBe(
+			"<a/>",
+		);
+	});
+
+	it("does not treat a lookalike type like application/jsonp as textual", () => {
+		const bytes = Buffer.from([1, 2, 3]);
+		expect(encodeRequestBody(bytes, "application/jsonp")).toBe(
+			bytes.toString("base64"),
+		);
+	});
+});
+
+describe("isJsonContentType", () => {
+	it("matches application/json and structured-syntax-suffix JSON types", () => {
+		expect(isJsonContentType("application/json")).toBe(true);
+		expect(isJsonContentType("application/json; charset=utf-8")).toBe(true);
+		expect(isJsonContentType("application/ld+json")).toBe(true);
+	});
+
+	it("does not match non-JSON or missing content types", () => {
+		expect(isJsonContentType("application/xml")).toBe(false);
+		expect(isJsonContentType("application/jsonp")).toBe(false);
+		expect(isJsonContentType(undefined)).toBe(false);
+	});
+});
+
+describe("isFormContentType", () => {
+	it("matches url-encoded and multipart form bodies", () => {
+		expect(isFormContentType("application/x-www-form-urlencoded")).toBe(true);
+		expect(isFormContentType("multipart/form-data; boundary=----abc")).toBe(
+			true,
+		);
+	});
+
+	it("does not match non-form or missing content types", () => {
+		expect(isFormContentType("application/json")).toBe(false);
+		expect(isFormContentType(undefined)).toBe(false);
 	});
 });

--- a/test/routes/http-methods/raw-body.test.ts
+++ b/test/routes/http-methods/raw-body.test.ts
@@ -1,0 +1,77 @@
+import Fastify from "fastify";
+import { describe, expect, it } from "vitest";
+import {
+	encodeRequestBody,
+	registerRawBodyFallbackParser,
+} from "../../../src/routes/http-methods/raw-body.js";
+
+describe("registerRawBodyFallbackParser", () => {
+	it("captures a body whose content type Fastify doesn't otherwise handle as a raw Buffer", async () => {
+		const fastify = Fastify();
+		registerRawBodyFallbackParser(fastify);
+		fastify.post("/echo", async (request) => {
+			expect(Buffer.isBuffer(request.body)).toBe(true);
+			return { length: (request.body as Buffer).length };
+		});
+
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/echo",
+			payload: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+			headers: { "content-type": "application/octet-stream" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ length: 4 });
+
+		await fastify.close();
+	});
+
+	it("does not change how application/json bodies are already parsed", async () => {
+		const fastify = Fastify();
+		registerRawBodyFallbackParser(fastify);
+		fastify.post("/echo", async (request) => request.body);
+
+		const response = await fastify.inject({
+			method: "POST",
+			url: "/echo",
+			payload: { a: 1 },
+			headers: { "content-type": "application/json" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ a: 1 });
+
+		await fastify.close();
+	});
+});
+
+describe("encodeRequestBody", () => {
+	it("passes non-Buffer bodies through unchanged", () => {
+		expect(encodeRequestBody({ a: 1 }, "application/json")).toEqual({ a: 1 });
+		expect(encodeRequestBody("hello", "text/plain")).toBe("hello");
+		expect(encodeRequestBody(undefined, undefined)).toBeUndefined();
+		expect(encodeRequestBody(null, undefined)).toBeNull();
+	});
+
+	it("decodes a Buffer as utf8 text for a textual content type", () => {
+		const body = Buffer.from("<a>hi</a>", "utf8");
+		expect(encodeRequestBody(body, "application/xml")).toBe("<a>hi</a>");
+	});
+
+	it("base64-encodes a Buffer for a binary content type", () => {
+		const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+		expect(encodeRequestBody(png, "image/png")).toBe(png.toString("base64"));
+	});
+
+	it("base64-encodes a Buffer when the content type is missing", () => {
+		const bytes = Buffer.from([1, 2, 3]);
+		expect(encodeRequestBody(bytes, undefined)).toBe(bytes.toString("base64"));
+	});
+
+	it("returns an empty string for an empty Buffer", () => {
+		expect(encodeRequestBody(Buffer.alloc(0), "application/octet-stream")).toBe(
+			"",
+		);
+	});
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/mockhttp/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/jaredwray/mockhttp/blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Feature — `/post` and `/anything` now accept raw/binary request bodies instead of rejecting anything that isn't `application/json`. Includes one documented behavior change (see below).

---

## Summary

`/post` and `/anything` currently reject any request body whose `Content-Type` isn't `application/json` (or `text/plain`) with `415 Unsupported Media Type`, since Fastify only registers parsers for those two content types by default:

```
$ curl -s -X POST -H "Content-Type: image/png" --data-binary @test.png http://127.0.0.1:3000/post
{"statusCode":415,"code":"FST_ERR_CTP_INVALID_MEDIA_TYPE","error":"Unsupported Media Type","message":"Unsupported Media Type"}
```

That means image uploads, arbitrary binary payloads, `multipart/form-data`, or any client sending `Content-Type: application/octet-stream` can't be exercised against these routes at all — unlike httpbin/httpbun, where posting arbitrary bytes to these kinds of endpoints is a common use case (this is the last of the compatibility gaps I found migrating a project's test suite onto mockhttp.org, alongside #160, #161, #162).

## Fix

Adds a shared `registerRawBodyFallbackParser()` (`src/routes/http-methods/raw-body.ts`) that registers a `"*"` catch-all content-type parser, scoped to each route's own plugin encapsulation (`fastify.register(postRoute)` / `fastify.register(anythingRoute)`), so it only fills in the gap for content types nothing else already handles — it doesn't change how `application/json` (or, on top of #161, `application/x-www-form-urlencoded`) bodies are parsed.

The accompanying `encodeRequestBody()` decides how to represent a raw `Buffer` in the response: utf8 text for textual content types, base64 otherwise — the same rule `src/routes/bins/capture.ts` already uses for its request-bin bodies, so this doesn't introduce a new convention.

`/post`'s response schema for `body` is relaxed from a strict `{type: "object"}` to accept any value, matching how the `DELETE` route's response schema already uses `oneOf: [object, string, null]` for the same field. `/anything`'s `data`/`form`/`json` fields are relaxed the same way; the `AnythingResponse` type is updated to match.

**One behavior change worth flagging explicitly:** a POST to `/post` or `/anything` with no body/Content-Type at all now returns `200` with `body: {}` instead of a strict `400` — since the whole point of this change is accepting a much broader range of bodies, requiring a well-formed object was no longer the right default. I actually caught this as a `500` crash regression against my first draft via a manual curl check (fast-json-stringify choking on the `body` field being `undefined` against the response schema's `required`), fixed it, and added a dedicated regression test for it (the "empty body" cases in `post.test.ts` and `anything/index.test.ts`).

## Test plan
- [x] New `test/routes/http-methods/raw-body.test.ts` covering `registerRawBodyFallbackParser` and `encodeRequestBody` directly (binary capture, JSON untouched, utf8 vs base64 selection, empty buffer, non-Buffer passthrough).
- [x] Added binary-body and empty-body regression tests to `post.test.ts` and `anything/index.test.ts`.
- [x] `pnpm test` (lint + full vitest run with coverage) passes locally: 484 tests, 100% line coverage, no lint warnings.
- [x] Manually verified against a local `tsx src/index.ts` instance: binary PNG upload, multipart upload, JSON object/array bodies, and the empty-body case all behave as expected; confirmed the pre-existing `400` became a `200`/`{}` deliberately (not the `500` from my first draft).
