### PR TITLE
feat: add unbuffered param to /drip to opt out of reverse-proxy response buffering

### DIFF
--- a/src/routes/dynamic-data/drip.ts
+++ b/src/routes/dynamic-data/drip.ts
@@ -11,7 +11,7 @@ type DripRequest = FastifyRequest<{
 		numbytes?: string;
 		code?: string;
 		delay?: string;
-		no_buffering?: string;
+		unbuffered?: string;
 	};
 }>;
 
@@ -39,7 +39,7 @@ const dripSchema: FastifySchema = {
 				type: "string",
 				description: "Initial delay in seconds before starting (default: 2)",
 			},
-			no_buffering: {
+			unbuffered: {
 				type: "string",
 				description:
 					"When 'true' or '1', sets the X-Accel-Buffering: no response header, asking any buffering reverse proxy in front of this server (e.g. Cloudflare, nginx) to stream bytes through as they're written instead of holding the full response until it's complete. Off by default since it has no effect running directly against this server and is only useful when deployed behind such a proxy.",
@@ -138,8 +138,8 @@ export const dripRoute = (fastify: FastifyInstance) => {
 			// nginx directive, also honored by Cloudflare) for asking a proxy
 			// to pass bytes through as written instead of buffering them.
 			if (
-				request.query.no_buffering === "true" ||
-				request.query.no_buffering === "1"
+				request.query.unbuffered === "true" ||
+				request.query.unbuffered === "1"
 			) {
 				headers["X-Accel-Buffering"] = "no";
 			}

--- a/src/routes/dynamic-data/drip.ts
+++ b/src/routes/dynamic-data/drip.ts
@@ -11,6 +11,7 @@ type DripRequest = FastifyRequest<{
 		numbytes?: string;
 		code?: string;
 		delay?: string;
+		no_buffering?: string;
 	};
 }>;
 
@@ -37,6 +38,11 @@ const dripSchema: FastifySchema = {
 			delay: {
 				type: "string",
 				description: "Initial delay in seconds before starting (default: 2)",
+			},
+			no_buffering: {
+				type: "string",
+				description:
+					"When 'true' or '1', sets the X-Accel-Buffering: no response header, asking any buffering reverse proxy in front of this server (e.g. Cloudflare, nginx) to stream bytes through as they're written instead of holding the full response until it's complete. Off by default since it has no effect running directly against this server and is only useful when deployed behind such a proxy.",
 			},
 		},
 	},
@@ -120,10 +126,24 @@ export const dripRoute = (fastify: FastifyInstance) => {
 			}
 
 			// Set headers - NOT using chunked encoding (per httpbin spec)
-			reply.raw.writeHead(code, {
+			const headers: Record<string, string> = {
 				"Content-Type": "application/octet-stream",
 				"Content-Length": actualBytes.toString(),
-			});
+			};
+			// A reverse proxy sitting in front of this server (this is how
+			// mockhttp.org itself is deployed - see the "Cloudflare" section of
+			// the README) may buffer the whole response before forwarding it,
+			// which defeats the entire point of "drip"-ing bytes over time.
+			// X-Accel-Buffering: no is a de facto standard (originally an
+			// nginx directive, also honored by Cloudflare) for asking a proxy
+			// to pass bytes through as written instead of buffering them.
+			if (
+				request.query.no_buffering === "true" ||
+				request.query.no_buffering === "1"
+			) {
+				headers["X-Accel-Buffering"] = "no";
+			}
+			reply.raw.writeHead(code, headers);
 
 			if (actualBytes === 0) {
 				reply.raw.end();

--- a/test/routes/dynamic-data/drip.test.ts
+++ b/test/routes/dynamic-data/drip.test.ts
@@ -101,4 +101,37 @@ describe("GET /drip route", () => {
 		expect(response.statusCode).toBe(200);
 		expect(endTime - startTime).toBeGreaterThanOrEqual(80); // Allow some tolerance
 	});
+
+	it("should not set X-Accel-Buffering by default", async () => {
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/drip?numbytes=1&duration=0&delay=0",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["x-accel-buffering"]).toBeUndefined();
+	});
+
+	it.each([
+		"true",
+		"1",
+	])("should set X-Accel-Buffering: no when no_buffering=%s", async (value) => {
+		const response = await fastify.inject({
+			method: "GET",
+			url: `/drip?numbytes=1&duration=0&delay=0&no_buffering=${value}`,
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["x-accel-buffering"]).toBe("no");
+	});
+
+	it("should not set X-Accel-Buffering for an unrecognized no_buffering value", async () => {
+		const response = await fastify.inject({
+			method: "GET",
+			url: "/drip?numbytes=1&duration=0&delay=0&no_buffering=yes",
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers["x-accel-buffering"]).toBeUndefined();
+	});
 });

--- a/test/routes/dynamic-data/drip.test.ts
+++ b/test/routes/dynamic-data/drip.test.ts
@@ -115,20 +115,20 @@ describe("GET /drip route", () => {
 	it.each([
 		"true",
 		"1",
-	])("should set X-Accel-Buffering: no when no_buffering=%s", async (value) => {
+	])("should set X-Accel-Buffering: no when unbuffered=%s", async (value) => {
 		const response = await fastify.inject({
 			method: "GET",
-			url: `/drip?numbytes=1&duration=0&delay=0&no_buffering=${value}`,
+			url: `/drip?numbytes=1&duration=0&delay=0&unbuffered=${value}`,
 		});
 
 		expect(response.statusCode).toBe(200);
 		expect(response.headers["x-accel-buffering"]).toBe("no");
 	});
 
-	it("should not set X-Accel-Buffering for an unrecognized no_buffering value", async () => {
+	it("should not set X-Accel-Buffering for an unrecognized unbuffered value", async () => {
 		const response = await fastify.inject({
 			method: "GET",
-			url: "/drip?numbytes=1&duration=0&delay=0&no_buffering=yes",
+			url: "/drip?numbytes=1&duration=0&delay=0&unbuffered=yes",
 		});
 
 		expect(response.statusCode).toBe(200);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/mockhttp/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/jaredwray/mockhttp/blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Feature — opt-in `unbuffered` query param on `/drip` to ask a fronting reverse proxy not to buffer the streamed response.

---

## Summary

`/drip` already does correct per-byte streaming at the application layer — `reply.raw.write()` one byte at a time with a real `setTimeout` between each write (`src/routes/dynamic-data/drip.ts`). But on the hosted `mockhttp.org` instance, which this repo's own README documents as running behind **Cloudflare + Google Cloud Run**, none of that per-byte timing survives to the client.

I confirmed this with three separate raw TLS socket captures (bypassing curl's own buffering to see exactly when bytes arrive on the wire):

```
GET /drip?duration=5&delay=1&numbytes=4096       -> entire response in one burst at t=6.32s
GET /stream-bytes/40960?chunk_size=1024          -> entire response in one burst at t=0.082s
GET /stream/20                                   -> entire response in one burst at t=0.079s
```

In every case, regardless of the requested `duration`/`delay`/`chunk_size`, the whole response arrives within tens of milliseconds — something in front of the app is buffering the complete response before releasing any of it. I ran into this migrating a project's `onprogress` test off httpbun, where it depended on genuinely incremental delivery to fire multiple progress events over a real download.

## Fix

`X-Accel-Buffering: no` is a de facto standard response header (originally an nginx directive) that [Cloudflare documents honoring](https://developers.cloudflare.com/cache/troubleshooting/buffered-response/) to disable response buffering for a specific response. Since the app already streams correctly and the proxy layer is what's erasing it, this seemed like the right lever to expose rather than changing `/drip`'s actual timing/content behavior.

Added it as an **opt-in** `unbuffered=true|1` query param (default behavior unchanged), not always-on, for two reasons:
- It has zero effect running directly against this server (only matters behind a buffering proxy) — no reason to always set it.
- I have no way to verify from here whether Cloudflare actually honors it for `mockhttp.org`'s specific Cloudflare + Cloud Run setup — only that the header is the documented, standard way to ask. I didn't want to claim this "fixes" streaming on the hosted instance when I can't confirm that end-to-end; opt-in lets you try it without committing to a behavior change if it turns out not to help.

**Naming note:** I initially called this `no_buffering`, but renamed it to `unbuffered` — a name with an embedded negation reads oddly if the off-state is ever set explicitly (`no_buffering=false` is a double negative), and `unbuffered` is standard, positively-framed terminology that doesn't require the caller to know a proxy is even involved.

**I'm happy to help verify post-deploy** with the same raw-socket capture methodology above, if that's useful once this lands on `mockhttp.org`.

## Test plan
- [x] Added tests in `test/routes/dynamic-data/drip.test.ts`: header absent by default, present (`no`) for `unbuffered=true` and `unbuffered=1`, absent for an unrecognized value.
- [x] `pnpm test` (lint + full vitest run with coverage) passes locally: 477 tests, 100% line coverage, no lint warnings.
- [x] Manually verified against a local `tsx src/index.ts` instance: header present only when `unbuffered=true` is passed, absent otherwise.
