### PR TITLE
chore: update @fastify/static to 10 (major)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"@fastify/cookie": "^11.1.1",
 		"@fastify/helmet": "^13.1.0",
 		"@fastify/rate-limit": "^11.1.0",
-		"@fastify/static": "^9.1.3",
+		"@fastify/static": "^10.1.0",
 		"@fastify/swagger": "^9.8.0",
 		"@fastify/swagger-ui": "^6.1.0",
 		"@scalar/api-reference": "^1.62.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       '@fastify/static':
-        specifier: ^9.1.3
-        version: 9.1.3
+        specifier: ^10.1.0
+        version: 10.1.0
       '@fastify/swagger':
         specifier: ^9.8.0
         version: 9.8.0
@@ -614,6 +614,9 @@ packages:
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@10.1.0':
+    resolution: {integrity: sha512-iK/8TvRM/EgNOyQL+EpWu+x3aR6o4GWt+UI+27zmE7w6t/6d80mXqOtWLdEKQ13vL/g1Jry0ae2icj6GP7tGzA==}
 
   '@fastify/static@9.1.3':
     resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
@@ -1518,6 +1521,10 @@ packages:
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
   convert-hrtime@5.0.0:
@@ -3291,6 +3298,16 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
+  '@fastify/static@10.1.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/error': 4.2.0
+      '@fastify/send': 4.1.0
+      content-disposition: 2.0.1
+      fastify-plugin: 6.0.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
   '@fastify/static@9.1.3':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
@@ -4330,6 +4347,8 @@ snapshots:
   commander@4.1.1: {}
 
   content-disposition@1.1.0: {}
+
+  content-disposition@2.0.1: {}
 
   convert-hrtime@5.0.0: {}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A (dependency-only change); the existing suite (473 tests) passes and coverage is unchanged.

**What kind of change does this PR introduce?**

Chore — **major** dependency update: `@fastify/static` 9 → 10. No source code changes required.

---

## Update — major

| Package | From | To |
| --- | --- | --- |
| @fastify/static | 9.1.3 | 10.1.0 |

### Breaking change assessment

The only breaking change in `@fastify/static` v10 is that the **`setHeaders`** option now receives a `FastifyReply` instead of a Node.js response object. This project **does not use `setHeaders`** — it only registers the plugin with `root`, `prefix`, and `decorateReply` (see `src/mock-http.ts`). **No code changes are required**, and the full test suite (which exercises both the `/scalar` static mount and favicon serving) passes unchanged.

## Verification

- **Build:** Passed
- **Lint (Biome) + tests (Vitest w/ coverage):** Passed
- **473 tests** across 43 files; **coverage unchanged** (100% lines/functions)

## Context — final PR of the grouped maintenance series

Last of the per-family dependency PRs (one at a time). Merged: #174 (Fastify stack), #175 (build tooling), #176 (@scalar/api-reference), #177 (hookified).

**Still deferred (not in this series):** `typescript` 7.0.2 — the build toolchain flags TS 7 as experimental with an unstable API, and it's exact-pinned, so it warrants its own deliberate upgrade. `tsdown` is held at 0.22.2 (0.22.4 drops Node 24.0–24.10 support).

---
Automated by the `project-maintenance` skill.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdfeGrhVzDqajGuC7eRo3R)_