### PR TITLE
feat: add stable response format output via optional template index

### DIFF
--- a/src/routes/response-formats/index.ts
+++ b/src/routes/response-formats/index.ts
@@ -6,59 +6,93 @@ import type {
 	FastifySchema,
 } from "fastify";
 
+const templateIndexParams = {
+	type: "object",
+	properties: {
+		index: {
+			type: "string",
+			description:
+				"Optional 1-based template index for stable, repeatable output. Omit for a random template.",
+		},
+	},
+};
+
+const templateNotFoundResponse = {
+	type: "object",
+	description: "The requested template index does not exist",
+	properties: {
+		error: { type: "string" },
+	},
+};
+
 const plainSchema: FastifySchema = {
-	description: "Returns random plain text content",
+	description:
+		"Returns plain text content. A random template is selected unless a 1-based template index is provided (e.g. /plain/1) for stable output.",
 	tags: ["Response Formats"],
+	params: templateIndexParams,
 	response: {
 		200: {
 			type: "string",
-			description: "Random plain text content",
+			description: "Plain text content",
 		},
+		404: templateNotFoundResponse,
 	},
 };
 
 const textSchema: FastifySchema = {
-	description: "Returns random text content",
+	description:
+		"Returns text content. A random template is selected unless a 1-based template index is provided (e.g. /text/1) for stable output.",
 	tags: ["Response Formats"],
+	params: templateIndexParams,
 	response: {
 		200: {
 			type: "string",
-			description: "Random text content",
+			description: "Text content",
 		},
+		404: templateNotFoundResponse,
 	},
 };
 
 const htmlSchema: FastifySchema = {
-	description: "Returns random HTML content",
+	description:
+		"Returns HTML content. A random template is selected unless a 1-based template index is provided (e.g. /html/1) for stable output.",
 	tags: ["Response Formats"],
+	params: templateIndexParams,
 	response: {
 		200: {
 			type: "string",
-			description: "Random HTML content",
+			description: "HTML content",
 		},
+		404: templateNotFoundResponse,
 	},
 };
 
 const xmlSchema: FastifySchema = {
-	description: "Returns random XML content",
+	description:
+		"Returns XML content. A random template is selected unless a 1-based template index is provided (e.g. /xml/1) for stable output.",
 	tags: ["Response Formats"],
+	params: templateIndexParams,
 	response: {
 		200: {
 			type: "string",
-			description: "Random XML content",
+			description: "XML content",
 		},
+		404: templateNotFoundResponse,
 	},
 };
 
 const jsonSchema: FastifySchema = {
-	description: "Returns random JSON content",
+	description:
+		"Returns JSON content. A random template is selected unless a 1-based template index is provided (e.g. /json/1) for stable output.",
 	tags: ["Response Formats"],
+	params: templateIndexParams,
 	response: {
 		200: {
 			type: "object",
-			description: "Random JSON content",
+			description: "JSON content",
 			additionalProperties: true,
 		},
+		404: templateNotFoundResponse,
 	},
 };
 
@@ -210,7 +244,7 @@ const randomXmlContent = [
 	`<?xml version="1.0" encoding="UTF-8"?>
 <root>
     <message>Hello from MockHTTP</message>
-    <timestamp>${new Date().toISOString()}</timestamp>
+    <timestamp>2024-01-15T10:30:00.000Z</timestamp>
     <status>success</status>
 </root>`,
 	`<?xml version="1.0" encoding="UTF-8"?>
@@ -253,20 +287,20 @@ const randomXmlContent = [
             <title>First Article</title>
             <link>http://example.com/article1</link>
             <description>This is the first article in our feed</description>
-            <pubDate>${new Date().toUTCString()}</pubDate>
+            <pubDate>Mon, 15 Jan 2024 10:30:00 GMT</pubDate>
         </item>
     </channel>
 </rss>`,
 ];
 
 const randomJsonContent = [
-	() => ({
+	{
 		message: "Hello from MockHTTP",
-		timestamp: new Date().toISOString(),
+		timestamp: "2024-01-15T10:30:00.000Z",
 		status: "success",
 		code: 200,
-	}),
-	() => ({
+	},
+	{
 		user: {
 			id: 1,
 			name: "John Doe",
@@ -275,8 +309,8 @@ const randomJsonContent = [
 			createdAt: "2024-01-15T10:30:00Z",
 		},
 		permissions: ["read", "write", "delete"],
-	}),
-	() => ({
+	},
+	{
 		products: [
 			{
 				id: 101,
@@ -293,8 +327,8 @@ const randomJsonContent = [
 		],
 		total: 2,
 		page: 1,
-	}),
-	() => ({
+	},
+	{
 		config: {
 			theme: "dark",
 			language: "en",
@@ -308,8 +342,8 @@ const randomJsonContent = [
 				activity: "friends",
 			},
 		},
-	}),
-	() => ({
+	},
+	{
 		metrics: {
 			cpu: 45.2,
 			memory: 78.5,
@@ -325,83 +359,133 @@ const randomJsonContent = [
 				{ name: "cache", status: "warning" },
 			],
 		},
-	}),
+	},
 ];
+
+type TemplateRequest = FastifyRequest<{ Params: { index?: string } }>;
+
+// Resolves the optional 1-based index parameter to an array position.
+// Returns a random position when no index is given, or -1 when the index
+// is not an integer between 1 and length.
+const resolveTemplateIndex = (
+	index: string | undefined,
+	length: number,
+): number => {
+	if (index === undefined) {
+		return Math.floor(Math.random() * length);
+	}
+
+	const value = Number(index);
+	if (!Number.isInteger(value) || value < 1 || value > length) {
+		return -1;
+	}
+
+	return value - 1;
+};
+
+const templateNotFound = (reply: FastifyReply, length: number) =>
+	reply.code(404).send({
+		error: `Template index must be between 1 and ${length}`,
+	});
 
 export const responseFormatRoutes = (fastify: FastifyInstance) => {
 	const plainHandler = async (
-		_request: FastifyRequest,
+		request: TemplateRequest,
 		reply: FastifyReply,
 	) => {
-		const randomIndex = Math.floor(Math.random() * randomTexts.length);
-		const text = randomTexts[randomIndex];
+		const index = resolveTemplateIndex(
+			request.params.index,
+			randomTexts.length,
+		);
+		if (index === -1) {
+			return templateNotFound(reply, randomTexts.length);
+		}
 
 		reply.type("text/plain");
-		return text;
+		return randomTexts[index];
 	};
 
-	fastify.get("/plain", { schema: plainSchema }, plainHandler);
-	fastify.post("/plain", { schema: plainSchema }, plainHandler);
-	fastify.put("/plain", { schema: plainSchema }, plainHandler);
-	fastify.patch("/plain", { schema: plainSchema }, plainHandler);
-	fastify.delete("/plain", { schema: plainSchema }, plainHandler);
+	fastify.get("/plain/:index?", { schema: plainSchema }, plainHandler);
+	fastify.post("/plain/:index?", { schema: plainSchema }, plainHandler);
+	fastify.put("/plain/:index?", { schema: plainSchema }, plainHandler);
+	fastify.patch("/plain/:index?", { schema: plainSchema }, plainHandler);
+	fastify.delete("/plain/:index?", { schema: plainSchema }, plainHandler);
 
-	const textHandler = async (_request: FastifyRequest, reply: FastifyReply) => {
-		const randomIndex = Math.floor(Math.random() * randomTexts.length);
-		const text = randomTexts[randomIndex];
+	const textHandler = async (request: TemplateRequest, reply: FastifyReply) => {
+		const index = resolveTemplateIndex(
+			request.params.index,
+			randomTexts.length,
+		);
+		if (index === -1) {
+			return templateNotFound(reply, randomTexts.length);
+		}
 
 		reply.type("text/plain");
-		return text;
+		return randomTexts[index];
 	};
 
-	fastify.get("/text", { schema: textSchema }, textHandler);
-	fastify.post("/text", { schema: textSchema }, textHandler);
-	fastify.put("/text", { schema: textSchema }, textHandler);
-	fastify.patch("/text", { schema: textSchema }, textHandler);
-	fastify.delete("/text", { schema: textSchema }, textHandler);
+	fastify.get("/text/:index?", { schema: textSchema }, textHandler);
+	fastify.post("/text/:index?", { schema: textSchema }, textHandler);
+	fastify.put("/text/:index?", { schema: textSchema }, textHandler);
+	fastify.patch("/text/:index?", { schema: textSchema }, textHandler);
+	fastify.delete("/text/:index?", { schema: textSchema }, textHandler);
 
-	const htmlHandler = async (_request: FastifyRequest, reply: FastifyReply) => {
-		const randomIndex = Math.floor(Math.random() * randomHtmlContent.length);
-		const html = randomHtmlContent[randomIndex];
+	const htmlHandler = async (request: TemplateRequest, reply: FastifyReply) => {
+		const index = resolveTemplateIndex(
+			request.params.index,
+			randomHtmlContent.length,
+		);
+		if (index === -1) {
+			return templateNotFound(reply, randomHtmlContent.length);
+		}
 
 		reply.type("text/html");
-		return html;
+		return randomHtmlContent[index];
 	};
 
-	fastify.get("/html", { schema: htmlSchema }, htmlHandler);
-	fastify.post("/html", { schema: htmlSchema }, htmlHandler);
-	fastify.put("/html", { schema: htmlSchema }, htmlHandler);
-	fastify.patch("/html", { schema: htmlSchema }, htmlHandler);
-	fastify.delete("/html", { schema: htmlSchema }, htmlHandler);
+	fastify.get("/html/:index?", { schema: htmlSchema }, htmlHandler);
+	fastify.post("/html/:index?", { schema: htmlSchema }, htmlHandler);
+	fastify.put("/html/:index?", { schema: htmlSchema }, htmlHandler);
+	fastify.patch("/html/:index?", { schema: htmlSchema }, htmlHandler);
+	fastify.delete("/html/:index?", { schema: htmlSchema }, htmlHandler);
 
-	const xmlHandler = async (_request: FastifyRequest, reply: FastifyReply) => {
-		const randomIndex = Math.floor(Math.random() * randomXmlContent.length);
-		const xml = randomXmlContent[randomIndex];
+	const xmlHandler = async (request: TemplateRequest, reply: FastifyReply) => {
+		const index = resolveTemplateIndex(
+			request.params.index,
+			randomXmlContent.length,
+		);
+		if (index === -1) {
+			return templateNotFound(reply, randomXmlContent.length);
+		}
 
 		reply.type("application/xml");
-		return xml;
+		return randomXmlContent[index];
 	};
 
-	fastify.get("/xml", { schema: xmlSchema }, xmlHandler);
-	fastify.post("/xml", { schema: xmlSchema }, xmlHandler);
-	fastify.put("/xml", { schema: xmlSchema }, xmlHandler);
-	fastify.patch("/xml", { schema: xmlSchema }, xmlHandler);
-	fastify.delete("/xml", { schema: xmlSchema }, xmlHandler);
+	fastify.get("/xml/:index?", { schema: xmlSchema }, xmlHandler);
+	fastify.post("/xml/:index?", { schema: xmlSchema }, xmlHandler);
+	fastify.put("/xml/:index?", { schema: xmlSchema }, xmlHandler);
+	fastify.patch("/xml/:index?", { schema: xmlSchema }, xmlHandler);
+	fastify.delete("/xml/:index?", { schema: xmlSchema }, xmlHandler);
 
-	const jsonHandler = async (_request: FastifyRequest, reply: FastifyReply) => {
-		const randomIndex = Math.floor(Math.random() * randomJsonContent.length);
-		const jsonGenerator = randomJsonContent[randomIndex];
-		const json = jsonGenerator();
+	const jsonHandler = async (request: TemplateRequest, reply: FastifyReply) => {
+		const index = resolveTemplateIndex(
+			request.params.index,
+			randomJsonContent.length,
+		);
+		if (index === -1) {
+			return templateNotFound(reply, randomJsonContent.length);
+		}
 
 		reply.type("application/json");
-		return json;
+		return randomJsonContent[index];
 	};
 
-	fastify.get("/json", { schema: jsonSchema }, jsonHandler);
-	fastify.post("/json", { schema: jsonSchema }, jsonHandler);
-	fastify.put("/json", { schema: jsonSchema }, jsonHandler);
-	fastify.patch("/json", { schema: jsonSchema }, jsonHandler);
-	fastify.delete("/json", { schema: jsonSchema }, jsonHandler);
+	fastify.get("/json/:index?", { schema: jsonSchema }, jsonHandler);
+	fastify.post("/json/:index?", { schema: jsonSchema }, jsonHandler);
+	fastify.put("/json/:index?", { schema: jsonSchema }, jsonHandler);
+	fastify.patch("/json/:index?", { schema: jsonSchema }, jsonHandler);
+	fastify.delete("/json/:index?", { schema: jsonSchema }, jsonHandler);
 
 	const denyHandler = async (_request: FastifyRequest, reply: FastifyReply) => {
 		const denyMessages = [

--- a/src/routes/response-formats/index.ts
+++ b/src/routes/response-formats/index.ts
@@ -478,7 +478,9 @@ export const responseFormatRoutes = (fastify: FastifyInstance) => {
 		}
 
 		reply.type("application/json");
-		return randomJsonContent[index];
+		// Clone so hooks that mutate the payload cannot contaminate the
+		// shared template and break the stable output guarantee.
+		return structuredClone(randomJsonContent[index]);
 	};
 
 	fastify.get("/json/:index?", { schema: jsonSchema }, jsonHandler);

--- a/test/routes/response-formats/index.test.ts
+++ b/test/routes/response-formats/index.test.ts
@@ -722,6 +722,20 @@ describe("Plain, Text, and HTML Routes", () => {
 			}
 		});
 
+		it("should return 404 for a trailing slash without an index", async () => {
+			// /json/ resolves the optional param to an empty string; a
+			// malformed index must fail loudly rather than silently
+			// falling back to a random template.
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/json/",
+			});
+
+			expect(response.statusCode).toBe(404);
+			const json = JSON.parse(response.body);
+			expect(json.error).toBe("Template index must be between 1 and 5");
+		});
+
 		it("should return 404 for non-integer JSON indexes", async () => {
 			for (const index of ["abc", "1.5"]) {
 				const response = await fastify.inject({

--- a/test/routes/response-formats/index.test.ts
+++ b/test/routes/response-formats/index.test.ts
@@ -561,6 +561,225 @@ describe("Plain, Text, and HTML Routes", () => {
 		});
 	});
 
+	// Tests for stable template output via optional index parameter
+	describe("stable template output via /:index", () => {
+		it("should return identical JSON for the same index across multiple calls", async () => {
+			for (let index = 1; index <= 5; index++) {
+				const first = await fastify.inject({
+					method: "GET",
+					url: `/json/${index}`,
+				});
+				const second = await fastify.inject({
+					method: "GET",
+					url: `/json/${index}`,
+				});
+
+				expect(first.statusCode).toBe(200);
+				expect(first.headers["content-type"]).toContain("application/json");
+				expect(first.body).toBe(second.body);
+			}
+		});
+
+		it("should return the exact first JSON template for /json/1", async () => {
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/json/1",
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(JSON.parse(response.body)).toEqual({
+				message: "Hello from MockHTTP",
+				timestamp: "2024-01-15T10:30:00.000Z",
+				status: "success",
+				code: 200,
+			});
+		});
+
+		it("should return distinct JSON templates for distinct indexes", async () => {
+			const bodies = new Set();
+
+			for (let index = 1; index <= 5; index++) {
+				const response = await fastify.inject({
+					method: "GET",
+					url: `/json/${index}`,
+				});
+				expect(response.statusCode).toBe(200);
+				bodies.add(response.body);
+			}
+
+			expect(bodies.size).toBe(5);
+		});
+
+		it("should return stable JSON output for all HTTP methods", async () => {
+			const methods = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+			const bodies = new Set();
+
+			for (const method of methods) {
+				const response = await fastify.inject({
+					method,
+					url: "/json/2",
+				});
+				expect(response.statusCode).toBe(200);
+				bodies.add(response.body);
+			}
+
+			// Every method returns the exact same template
+			expect(bodies.size).toBe(1);
+			const json = JSON.parse([...bodies][0] as string);
+			expect(json.user.name).toBe("John Doe");
+			expect(json.permissions).toEqual(["read", "write", "delete"]);
+		});
+
+		it("should return the first text template for /plain/1", async () => {
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/plain/1",
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.headers["content-type"]).toContain("text/plain");
+			expect(response.body).toBe(
+				"The quick brown fox jumps over the lazy dog.",
+			);
+		});
+
+		it("should return identical plain text for the same index across calls", async () => {
+			for (let index = 1; index <= 10; index++) {
+				const first = await fastify.inject({
+					method: "GET",
+					url: `/plain/${index}`,
+				});
+				const second = await fastify.inject({
+					method: "GET",
+					url: `/plain/${index}`,
+				});
+
+				expect(first.statusCode).toBe(200);
+				expect(first.body).toBe(second.body);
+			}
+		});
+
+		it("should return identical text for the same index across calls", async () => {
+			const first = await fastify.inject({
+				method: "GET",
+				url: "/text/10",
+			});
+			const second = await fastify.inject({
+				method: "GET",
+				url: "/text/10",
+			});
+
+			expect(first.statusCode).toBe(200);
+			expect(first.headers["content-type"]).toContain("text/plain");
+			expect(first.body).toBe("Knowledge is power. France is bacon.");
+			expect(first.body).toBe(second.body);
+		});
+
+		it("should return identical HTML for the same index across calls", async () => {
+			const first = await fastify.inject({
+				method: "GET",
+				url: "/html/1",
+			});
+			const second = await fastify.inject({
+				method: "GET",
+				url: "/html/1",
+			});
+
+			expect(first.statusCode).toBe(200);
+			expect(first.headers["content-type"]).toContain("text/html");
+			expect(first.body).toContain("<title>Sample Page</title>");
+			expect(first.body).toBe(second.body);
+		});
+
+		it("should return identical XML for the same index across calls", async () => {
+			const first = await fastify.inject({
+				method: "GET",
+				url: "/xml/1",
+			});
+			const second = await fastify.inject({
+				method: "GET",
+				url: "/xml/1",
+			});
+
+			expect(first.statusCode).toBe(200);
+			expect(first.headers["content-type"]).toContain("application/xml");
+			expect(first.body).toContain(
+				"<timestamp>2024-01-15T10:30:00.000Z</timestamp>",
+			);
+			expect(first.body).toBe(second.body);
+		});
+
+		it("should return 404 for out-of-range JSON indexes", async () => {
+			for (const index of ["0", "6", "99", "-1"]) {
+				const response = await fastify.inject({
+					method: "GET",
+					url: `/json/${index}`,
+				});
+
+				expect(response.statusCode).toBe(404);
+				const json = JSON.parse(response.body);
+				expect(json.error).toBe("Template index must be between 1 and 5");
+			}
+		});
+
+		it("should return 404 for non-integer JSON indexes", async () => {
+			for (const index of ["abc", "1.5"]) {
+				const response = await fastify.inject({
+					method: "GET",
+					url: `/json/${index}`,
+				});
+
+				expect(response.statusCode).toBe(404);
+				const json = JSON.parse(response.body);
+				expect(json.error).toBe("Template index must be between 1 and 5");
+			}
+		});
+
+		it("should return 404 for invalid plain text indexes", async () => {
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/plain/11",
+			});
+
+			expect(response.statusCode).toBe(404);
+			const json = JSON.parse(response.body);
+			expect(json.error).toBe("Template index must be between 1 and 10");
+		});
+
+		it("should return 404 for invalid text indexes", async () => {
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/text/0",
+			});
+
+			expect(response.statusCode).toBe(404);
+			const json = JSON.parse(response.body);
+			expect(json.error).toBe("Template index must be between 1 and 10");
+		});
+
+		it("should return 404 for invalid HTML indexes", async () => {
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/html/6",
+			});
+
+			expect(response.statusCode).toBe(404);
+			const json = JSON.parse(response.body);
+			expect(json.error).toBe("Template index must be between 1 and 5");
+		});
+
+		it("should return 404 for invalid XML indexes", async () => {
+			const response = await fastify.inject({
+				method: "GET",
+				url: "/xml/abc",
+			});
+
+			expect(response.statusCode).toBe(404);
+			const json = JSON.parse(response.body);
+			expect(json.error).toBe("Template index must be between 1 and 5");
+		});
+	});
+
 	// Tests for /deny endpoint
 	describe("/deny endpoint", () => {
 		it("should return 403 Forbidden status", async () => {

--- a/test/routes/response-formats/index.test.ts
+++ b/test/routes/response-formats/index.test.ts
@@ -778,6 +778,42 @@ describe("Plain, Text, and HTML Routes", () => {
 			const json = JSON.parse(response.body);
 			expect(json.error).toBe("Template index must be between 1 and 5");
 		});
+
+		it("should keep stable JSON output when a hook mutates the payload", async () => {
+			const mutatingFastify = Fastify();
+			mutatingFastify.addHook(
+				"preSerialization",
+				async (_request, _reply, payload) => {
+					const data = payload as { permissions?: string[] };
+					if (Array.isArray(data.permissions)) {
+						data.permissions.push("mutated-by-hook");
+					}
+					return payload;
+				},
+			);
+			await mutatingFastify.register(responseFormatRoutes);
+
+			const first = await mutatingFastify.inject({
+				method: "GET",
+				url: "/json/2",
+			});
+			const second = await mutatingFastify.inject({
+				method: "GET",
+				url: "/json/2",
+			});
+
+			// The hook's mutation must not leak into the shared template
+			expect(first.statusCode).toBe(200);
+			expect(first.body).toBe(second.body);
+			expect(JSON.parse(second.body).permissions).toEqual([
+				"read",
+				"write",
+				"delete",
+				"mutated-by-hook",
+			]);
+
+			await mutatingFastify.close();
+		});
 	});
 
 	// Tests for /deny endpoint


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — fixes #180.

httpbin's `/json` output was stable between calls, which made responses comparable; mockhttp randomizes it. This PR adds the `/json/1`, `/json/2`, … endpoints suggested in the issue, applied consistently across all five content-format endpoints.

- `/plain`, `/text`, `/html`, `/xml`, and `/json` now accept an optional 1-based template index (e.g. `/json/1` … `/json/5`, `/plain/1` … `/plain/10`) that returns that fixed template, so repeated calls produce byte-identical output.
- Omitting the index keeps the existing random behavior, so `/json` etc. are fully backward compatible.
- An out-of-range or non-integer index returns `404` with `{"error": "Template index must be between 1 and N"}` rather than silently falling back to random output.
- The live timestamps embedded in the JSON and XML templates (`new Date()`) are now fixed literals — without this, a fixed index still wouldn't be byte-stable across requests or server replicas.
- Swagger schemas updated (index param + 404 response), so the generated API docs describe the new behavior.
- Added tests covering stable output per index, all HTTP methods, distinct templates per index, and invalid-index handling for every endpoint; coverage remains at 100% lines/functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xy1LT9B3FV7ugKLR1uWodh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xy1LT9B3FV7ugKLR1uWodh)_