### PR TITLE
mockhttp - chore: defense - add CODEOWNERS for high-risk paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #182 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #182 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `.github/CODEOWNERS` so high-risk paths (workflows, cloud bootstrap, scripts) require review from `@jaredwray`.

## Status update

`DEFENSE_IN_DEPTH.md`: CODEOWNERS → (PR pending)

Stacked on #182. Merge that first, then retarget this PR to `main` (or merge this stack in order).

## Changes
- Own `/.github/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/`

## Verification
- [x] CODEOWNERS matches the defense-in-depth-nodejs § 2 template
- [x] `pnpm test` already green on the parent docs revision (docs/CODEOWNERS only)

Reference: `defense-in-depth-nodejs` § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

