### PR TITLE
mockhttp - chore: defense - bootstrap Safe Chain for cloud agents

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+	"install": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+	"postCreateCommand": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,11 @@ MockHTTP is an HTTP mock server for testing, built with Fastify and TypeScript.
 
 - Run `pnpm test` to ensure all tests pass
 - Maintain 100% code coverage — add or update tests as needed
+
+## Safe Chain
+
+Package installs in this environment go through Aikido Safe Chain shims. Never bypass them:
+
+- Keep `~/.safe-chain/shims` first on `PATH`.
+- Do not call unshimmed `npm`, `pnpm`, `npx`, or `pnpx`.
+- Do not install packages with `curl | sh` or by pointing at a package manager outside the shim directory.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -10,7 +10,7 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
 
 ## 3. Dependencies (pnpm)
 - [ ] `packageManager: pnpm@11.3+` pinned in `package.json`

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -10,7 +10,7 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #184 pending)
 
 ## 3. Dependencies (pnpm)
 - [ ] `packageManager: pnpm@11.3+` pinned in `package.json`

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #182 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #182 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)

--- a/scripts/setup-cloud-environment.sh
+++ b/scripts/setup-cloud-environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# setup-cloud-environment.sh — Aikido Safe Chain bootstrap for Codespaces and Cursor Cloud Agents.
+#
+# Fail closed: never install dependencies unless Safe Chain shims are on PATH.
+# Copied into the target repo as scripts/setup-cloud-environment.sh.
+
+set -euo pipefail
+
+export SAFE_CHAIN_VERSION="1.5.15"
+SAFE_CHAIN_INSTALLER_SHA256="de0565e3d6346407a604e84e639e95fea8758748063da2216bbfdca5feda5dd2"
+SAFE_CHAIN_INSTALLER_URL="https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh"
+SAFE_CHAIN_SHIMS="${HOME}/.safe-chain/shims"
+SAFE_CHAIN_BIN="${HOME}/.safe-chain/bin"
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+	cd "$git_root"
+fi
+
+if [[ ! -f pnpm-lock.yaml ]]; then
+	echo "error: pnpm-lock.yaml is required; refusing to install without a frozen lockfile" >&2
+	exit 1
+fi
+
+if [[ -f package.json ]] && grep -q '"packageManager"' package.json && command -v corepack >/dev/null; then
+	corepack enable
+fi
+
+if ! command -v pnpm >/dev/null; then
+	echo "error: pnpm is required on PATH before Safe Chain can wrap it" >&2
+	exit 1
+fi
+
+installer=$(mktemp)
+trap 'rm -f "$installer"' EXIT
+
+curl -fsSL "$SAFE_CHAIN_INSTALLER_URL" -o "$installer"
+echo "${SAFE_CHAIN_INSTALLER_SHA256} ${installer}" | sha256sum -c -
+
+sh "$installer" --ci
+
+export PATH="${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:${PATH}"
+
+persist_shim_path() {
+	local rc="$1"
+	local line="export PATH=\"${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:\$PATH\""
+	if [[ -f "$rc" ]] && grep -Fq ".safe-chain/shims" "$rc"; then
+		return 0
+	fi
+	mkdir -p "$(dirname "$rc")"
+	printf '\n# Aikido Safe Chain shims\n%s\n' "$line" >> "$rc"
+}
+
+persist_shim_path "${HOME}/.profile"
+persist_shim_path "${HOME}/.bashrc"
+persist_shim_path "${HOME}/.zshrc"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+	printf '%s\n' "$SAFE_CHAIN_SHIMS" >> "$GITHUB_PATH"
+	printf '%s\n' "$SAFE_CHAIN_BIN" >> "$GITHUB_PATH"
+fi
+
+pnpm safe-chain-verify
+pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bootstrap Aikido Safe Chain on Codespaces and Cursor Cloud Agents so installs go through pinned, fail-closed shims.

## Status update

`DEFENSE_IN_DEPTH.md`: Safe Chain cloud bootstrap → (PR #184 pending)

Stacked on the docs branch after #183 merged into it. Merge #182 into `main` first, then this PR.

## Merge conflict

Simple, now resolved: both sides edited the Safe Chain catalog line. Kept this PR’s annotation `(PR #184 pending)` over the base branch’s unannotated line.

## Changes
- Add `scripts/setup-cloud-environment.sh` (Safe Chain 1.5.15, installer SHA-256 verified, `--ci`, frozen lockfile)
- Add `.devcontainer/devcontainer.json` and `.cursor/environment.json` that run the script
- Append the Safe Chain section to `AGENTS.md`

## Verification
- [x] `.devcontainer/devcontainer.json` and `.cursor/environment.json` parse as JSON
- [x] Script matches the skill bundle (pinned version + digest, fail closed)

Reference: `defense-in-depth-nodejs` § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

