### PR TITLE
mockhttp - chore: defense - shrink allowBuilds to proven exceptions

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+	"install": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "Node.js",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+	"postCreateCommand": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,11 @@ MockHTTP is an HTTP mock server for testing, built with Fastify and TypeScript.
 
 - Run `pnpm test` to ensure all tests pass
 - Maintain 100% code coverage — add or update tests as needed
+
+## Safe Chain
+
+Package installs in this environment go through Aikido Safe Chain shims. Never bypass them:
+
+- Keep `~/.safe-chain/shims` first on `PATH`.
+- Do not call unshimmed `npm`, `pnpm`, `npx`, or `pnpx`.
+- Do not install packages with `curl | sh` or by pointing at a package manager outside the shim directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ You can contribute changes to this repo by opening a pull request:
 
 1) After forking this repository to your Git account, make the proposed changes on your forked branch.
 2) Run tests and linting locally.
-	- Run `npm install -g pnpm` to install the package manager.
+	- Run `corepack enable` so the `packageManager` field in `package.json` provides pnpm.
 	- Run `pnpm install`.
 	- Run `pnpm test`.
 3) Commit your changes and push them to your forked repository.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -13,7 +13,7 @@ Profile: npm library · public
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #184 pending)
 
 ## 3. Dependencies (pnpm)
-- [ ] `packageManager: pnpm@11.3+` pinned in `package.json` (PR pending)
+- [ ] `packageManager: pnpm@11.3+` pinned in `package.json` (PR #185 pending)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified on main
 - [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
 - [x] `blockExoticSubdeps: true` — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -10,7 +10,7 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
 
 ## 3. Dependencies (pnpm)
 - [ ] `packageManager: pnpm@11.3+` pinned in `package.json`

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -13,7 +13,7 @@ Profile: npm library · public
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #184 pending)
 
 ## 3. Dependencies (pnpm)
-- [ ] `packageManager: pnpm@11.3+` pinned in `package.json`
+- [ ] `packageManager: pnpm@11.3+` pinned in `package.json` (PR pending)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified on main
 - [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
 - [x] `blockExoticSubdeps: true` — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -15,7 +15,7 @@ Profile: npm library · public
 ## 3. Dependencies (pnpm)
 - [ ] `packageManager: pnpm@11.3+` pinned in `package.json` (PR #185 pending)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified on main
-- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR pending)
+- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR #186 pending)
 - [x] `blockExoticSubdeps: true` — verified on main
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — verified on main
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -15,7 +15,7 @@ Profile: npm library · public
 ## 3. Dependencies (pnpm)
 - [ ] `packageManager: pnpm@11.3+` pinned in `package.json` (PR #185 pending)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — verified on main
-- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
+- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR pending)
 - [x] `blockExoticSubdeps: true` — verified on main
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — verified on main
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified on main

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -10,7 +10,7 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #184 pending)
 
 ## 3. Dependencies (pnpm)
 - [ ] `packageManager: pnpm@11.3+` pinned in `package.json`

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #182 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #183 pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #182 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"main": "dist/index.mjs",
 	"types": "dist/index.d.mts",
-	"packageManager": "pnpm@11.1.3",
+	"packageManager": "pnpm@11.20.0",
 	"engines": {
 		"node": ">=22.18.0"
 	},

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,9 +8,7 @@ trustPolicy: no-downgrade
 
 allowBuilds:
   '@swc/core': true
-  core-js: false
   esbuild: true
-  protobufjs: false
   vue-demi: true
 
 overrides:

--- a/scripts/setup-cloud-environment.sh
+++ b/scripts/setup-cloud-environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# setup-cloud-environment.sh — Aikido Safe Chain bootstrap for Codespaces and Cursor Cloud Agents.
+#
+# Fail closed: never install dependencies unless Safe Chain shims are on PATH.
+# Copied into the target repo as scripts/setup-cloud-environment.sh.
+
+set -euo pipefail
+
+export SAFE_CHAIN_VERSION="1.5.15"
+SAFE_CHAIN_INSTALLER_SHA256="de0565e3d6346407a604e84e639e95fea8758748063da2216bbfdca5feda5dd2"
+SAFE_CHAIN_INSTALLER_URL="https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh"
+SAFE_CHAIN_SHIMS="${HOME}/.safe-chain/shims"
+SAFE_CHAIN_BIN="${HOME}/.safe-chain/bin"
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+	cd "$git_root"
+fi
+
+if [[ ! -f pnpm-lock.yaml ]]; then
+	echo "error: pnpm-lock.yaml is required; refusing to install without a frozen lockfile" >&2
+	exit 1
+fi
+
+if [[ -f package.json ]] && grep -q '"packageManager"' package.json && command -v corepack >/dev/null; then
+	corepack enable
+fi
+
+if ! command -v pnpm >/dev/null; then
+	echo "error: pnpm is required on PATH before Safe Chain can wrap it" >&2
+	exit 1
+fi
+
+installer=$(mktemp)
+trap 'rm -f "$installer"' EXIT
+
+curl -fsSL "$SAFE_CHAIN_INSTALLER_URL" -o "$installer"
+echo "${SAFE_CHAIN_INSTALLER_SHA256} ${installer}" | sha256sum -c -
+
+sh "$installer" --ci
+
+export PATH="${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:${PATH}"
+
+persist_shim_path() {
+	local rc="$1"
+	local line="export PATH=\"${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:\$PATH\""
+	if [[ -f "$rc" ]] && grep -Fq ".safe-chain/shims" "$rc"; then
+		return 0
+	fi
+	mkdir -p "$(dirname "$rc")"
+	printf '\n# Aikido Safe Chain shims\n%s\n' "$line" >> "$rc"
+}
+
+persist_shim_path "${HOME}/.profile"
+persist_shim_path "${HOME}/.bashrc"
+persist_shim_path "${HOME}/.zshrc"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+	printf '%s\n' "$SAFE_CHAIN_SHIMS" >> "$GITHUB_PATH"
+	printf '%s\n' "$SAFE_CHAIN_BIN" >> "$GITHUB_PATH"
+fi
+
+pnpm safe-chain-verify
+pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reset `allowBuilds` to the empty baseline, then keep only the packages whose install scripts actually run: `@swc/core`, `esbuild`, and `vue-demi`.

## Status update

`DEFENSE_IN_DEPTH.md`: lifecycle scripts / `allowBuilds` → (PR pending)

Stacked on #185.

## Changes
- Drop unused `core-js` and `protobufjs` denials (deny is already the default)
- Keep reviewed `true` exceptions for the three ignored builds `pnpm install` reports with an empty map

## Verification
- [x] Empty `allowBuilds` fails with `ERR_PNPM_IGNORED_BUILDS` listing `@swc/core`, `esbuild`, `vue-demi`
- [x] `pnpm install --frozen-lockfile` succeeds with those three exceptions

Reference: `defense-in-depth-nodejs` § 3

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

