### PR TITLE
mockhttp - chore: defense - record repository lockdown

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -41,18 +41,19 @@ Profile: npm library · public
 
 ## 6. Security tooling
 - [x] Aikido runs on every build — GitHub app scans PRs
-- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (#191)
+- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (#191); Actions secret `AIKIDO_CLIENT_API_KEY` configured
 - [x] Socket reviews every PR that changes dependencies — GitHub app scans PRs
 
 ## 7. Repository lockdown
 - [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "build (22),build (24),build (26),Analyze (javascript),zizmor"` and `--allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"` passes (#193)
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
-- [ ] Recovery codes stored offline in a password manager (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub account (manual)
+- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the npm account (manual)
+- [x] GitHub recovery codes stored offline in a password manager (manual)
+- [ ] npm recovery codes stored offline in a password manager (manual)
 
 ## Remaining maintainer steps (manual)
 
-GitHub lockdown `--check` passed 2026-08-18 as a repo admin. Tick the boxes in this file when you finish each item.
+GitHub lockdown `--check` passed 2026-08-18 as a repo admin. `AIKIDO_CLIENT_API_KEY` and GitHub passkeys / recovery codes are in place. Tick the boxes in this file when you finish each item.
 
-1. Add Actions secret `AIKIDO_CLIENT_API_KEY` from Aikido CI settings — without it, a real release fails closed at `aikido-gate`.
-2. On npmjs.com for `@jaredwray/mockhttp`: trusted publisher = this repo, workflow filename `release.yaml`, environment `npm`, **stage-only**. Connect [Drydock](https://drydock.org). Require 2FA and disallow tokens.
-3. Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts. Store recovery codes offline.
+1. On npmjs.com for `@jaredwray/mockhttp`: trusted publisher = this repo, workflow filename `release.yaml`, environment `npm`, **stage-only**. Connect [Drydock](https://drydock.org). Require 2FA and disallow tokens.
+2. Phishing-resistant 2FA (passkeys / hardware keys) on the npm account. Store npm recovery codes offline.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -45,7 +45,7 @@ Profile: npm library · public
 - [x] Socket reviews every PR that changes dependencies — GitHub app scans PRs
 
 ## 7. Repository lockdown
-- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "build (22),build (24),build (26),Analyze (javascript),zizmor"` and `--allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"` passes (this PR)
+- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "build (22),build (24),build (26),Analyze (javascript),zizmor"` and `--allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"` passes (#193)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -19,7 +19,7 @@ Profile: npm library · public
 - [x] `blockExoticSubdeps: true` — verified on main
 - [x] Lockfile committed; CI installs with `sfw pnpm install --frozen-lockfile`
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified on main
-- [x] New direct dependencies get human review; prefer `~` ranges over `^` (this PR)
+- [x] New direct dependencies get human review; prefer `~` ranges over `^` (#192)
 
 ## 4. GitHub Actions
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — verified on main
@@ -45,27 +45,14 @@ Profile: npm library · public
 - [x] Socket reviews every PR that changes dependencies — GitHub app scans PRs
 
 ## 7. Repository lockdown
-- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable)
+- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "build (22),build (24),build (26),Analyze (javascript),zizmor"` and `--allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"` passes (this PR)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
 
-## Maintainer Stage 7 (last)
+## Remaining maintainer steps (manual)
 
-Do this after #192 is on `main`. Do not run `lockdown-repo.sh` in apply mode until you have audited `--check` as a repo admin.
+GitHub lockdown `--check` passed 2026-08-18 as a repo admin. Tick the boxes in this file when you finish each item.
 
-1. Confirm the **Aikido** and **Socket** GitHub apps (they already scan PRs). Add Actions secret `AIKIDO_CLIENT_API_KEY` from Aikido CI settings — without it, a real release fails closed at `aikido-gate`.
+1. Add Actions secret `AIKIDO_CLIENT_API_KEY` from Aikido CI settings — without it, a real release fails closed at `aikido-gate`.
 2. On npmjs.com for `@jaredwray/mockhttp`: trusted publisher = this repo, workflow filename `release.yaml`, environment `npm`, **stage-only**. Connect [Drydock](https://drydock.org). Require 2FA and disallow tokens.
 3. Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts. Store recovery codes offline.
-4. Download [`lockdown-repo.sh`](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/scripts/lockdown-repo.sh) (do not commit it here). Audit, then apply as a repo admin. Confirm check names from a green PR:
-
-```bash
-lockdown-repo.sh jaredwray/mockhttp --check \
-  --required-checks "build (22),build (24),build (26),Analyze,zizmor" \
-  --allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"
-
-lockdown-repo.sh jaredwray/mockhttp \
-  --required-checks "build (22),build (24),build (26),Analyze,zizmor" \
-  --allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"
-```
-
-5. Recording PR: tick the lockdown item in this file and expand the `SECURITY.md` summary to the full live end-state. Tick the `(manual)` boxes yourself.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -32,11 +32,11 @@ Profile: npm library · public
 - [x] No npm tokens in Actions secrets — verified on main (Docker Hub and GCP deploy still use long-lived registry credentials)
 
 ## 5. npm publishing — npm libraries only
-- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
 - [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (#190)
-- [ ] Maintainer promotes staged versions with 2FA (manual)
-- [ ] Drydock connected — staged releases reviewed before promotion (manual)
-- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] Maintainer promotes staged versions with 2FA (manual)
+- [x] Drydock connected — staged releases reviewed before promotion (manual)
+- [x] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified on main
 
 ## 6. Security tooling
@@ -47,13 +47,10 @@ Profile: npm library · public
 ## 7. Repository lockdown
 - [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "build (22),build (24),build (26),Analyze (javascript),zizmor"` and `--allowed-actions "codecov/*,peter-evans/*,google-github-actions/*,docker/*"` passes (#193)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub account (manual)
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the npm account (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the npm account (manual)
 - [x] GitHub recovery codes stored offline in a password manager (manual)
-- [ ] npm recovery codes stored offline in a password manager (manual)
+- [x] npm recovery codes stored offline in a password manager (manual)
 
-## Remaining maintainer steps (manual)
+## Release flow
 
-GitHub lockdown `--check` passed 2026-08-18 as a repo admin. `AIKIDO_CLIENT_API_KEY` and GitHub passkeys / recovery codes are in place. Tick the boxes in this file when you finish each item.
-
-1. On npmjs.com for `@jaredwray/mockhttp`: trusted publisher = this repo, workflow filename `release.yaml`, environment `npm`, **stage-only**. Connect [Drydock](https://drydock.org). Require 2FA and disallow tokens.
-2. Phishing-resistant 2FA (passkeys / hardware keys) on the npm account. Store npm recovery codes offline.
+Catalog complete. GitHub Releases can go live. `release.yaml` stages `@jaredwray/mockhttp` via OIDC; promote from [Drydock](https://drydock.org) with 2FA. Do not live-publish from CI.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,12 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md)
 hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
+- All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks (`build (22)`, `build (24)`, `build (26)`, `Analyze (javascript)`, `zizmor`).
+- Tags (and therefore releases) can only be created by repository admins.
+- Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
+- CI runs with read-only default workflow tokens; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
-- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with `--frozen-lockfile`.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`. CI installs with `--frozen-lockfile`. Socket reviews every dependency change; Aikido scans every build.
 - High-risk paths (`.github/`, `.cursor/`, `.devcontainer/`, `scripts/`) are owned in `.github/CODEOWNERS`.
-- npm releases are packed and staged via OIDC trusted publishing. There are no npm tokens. Drydock review and stage-only registry settings are the remaining maintainer steps.
-- Aikido scans every build. Socket reviews every pull request that changes dependencies.
+- npm releases are packed and staged via OIDC trusted publishing. There are no npm tokens. Drydock review and stage-only registry settings on npmjs.com are remaining maintainer steps.
+- Secret scanning and push protection are enabled. Private vulnerability reporting is enabled. Dependabot is off.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
 - CI runs with read-only default workflow tokens; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
-- Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`. CI installs with `--frozen-lockfile`. Socket reviews every dependency change; Aikido scans every build.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`. CI installs with `--frozen-lockfile`. Socket reviews every dependency change; Aikido scans every build. Releases are gated on Aikido `scan-release` (`AIKIDO_CLIENT_API_KEY`; scan only, no publish rights).
 - High-risk paths (`.github/`, `.cursor/`, `.devcontainer/`, `scripts/`) are owned in `.github/CODEOWNERS`.
 - npm releases are packed and staged via OIDC trusted publishing. There are no npm tokens. Drydock review and stage-only registry settings on npmjs.com are remaining maintainer steps.
 - Secret scanning and push protection are enabled. Private vulnerability reporting is enabled. Dependabot is off.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,5 +30,5 @@ hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_D
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`. CI installs with `--frozen-lockfile`. Socket reviews every dependency change; Aikido scans every build. Releases are gated on Aikido `scan-release` (`AIKIDO_CLIENT_API_KEY`; scan only, no publish rights).
 - High-risk paths (`.github/`, `.cursor/`, `.devcontainer/`, `scripts/`) are owned in `.github/CODEOWNERS`.
-- npm releases are packed and staged via OIDC trusted publishing. There are no npm tokens. Drydock review and stage-only registry settings on npmjs.com are remaining maintainer steps.
+- npm releases are packed and staged via OIDC trusted publishing (**stage-only** on npmjs.com; workflow `release.yaml`, environment `npm`). There are no npm tokens. Staged versions are reviewed in Drydock and promoted with 2FA; the package disallows tokens.
 - Secret scanning and push protection are enabled. Private vulnerability reporting is enabled. Dependabot is off.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update: record that the defense-in-depth catalog is complete.

## Why

Jared ran `lockdown-repo.sh --check` as a repo admin on 2026-08-18. He later confirmed `AIKIDO_CLIENT_API_KEY`, GitHub and npm passkeys / recovery codes, npmjs.com **stage-only** trusted publishing (`release.yaml`, environment `npm`), Drydock, and package 2FA with tokens disallowed. This PR only records those results. It does **not** re-apply lockdown.

## Changes

- Tick lockdown in `DEFENSE_IN_DEPTH.md` with the exact `--required-checks` / `--allowed-actions` that passed.
- Tick remaining `(manual)` items: npmjs.com stage-only, Drydock, package 2FA / no tokens, GitHub and npm passkeys and recovery codes, `AIKIDO_CLIENT_API_KEY`.
- Expand `SECURITY.md` to the live controls, including OIDC stage-only, Drydock promotion, and the Aikido `scan-release` gate.
- Replace remaining-steps with the release flow: GitHub Releases can go live; CI stages npm; promote from Drydock with 2FA.

## Verification

Docs-only. No runtime or CI workflow changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b6e6ca5-279e-4b40-8a60-ec37b31ab2df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

