### PR TITLE
root - chore: remove set-cookie-parser override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  set-cookie-parser: 2.7.2
   '@ungap/structured-clone': '>=1.3.1'
   glob@<=11.1.0: 11.1.0
 
@@ -27,13 +26,13 @@ importers:
         version: 10.1.0
       '@fastify/swagger':
         specifier: ~9.8.0
-        version: 9.8.0
+        version: 9.8.0(supports-color@7.2.0)
       '@fastify/swagger-ui':
         specifier: ~6.1.0
         version: 6.1.0
       '@scalar/api-reference':
         specifier: ~1.62.5
-        version: 1.62.5(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)
+        version: 1.62.5(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)
       detect-port:
         specifier: ~2.1.0
         version: 2.1.0
@@ -2467,6 +2466,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -3325,10 +3327,10 @@ snapshots:
       rfdc: 1.4.1
       yaml: 2.8.3
 
-  '@fastify/swagger@9.8.0':
+  '@fastify/swagger@9.8.0(supports-color@7.2.0)':
     dependencies:
       fastify-plugin: 6.0.0
-      json-schema-resolver: 3.0.0
+      json-schema-resolver: 3.0.0(supports-color@7.2.0)
       openapi-types: 12.1.3
       rfdc: 1.4.1
       yaml: 2.8.2
@@ -3610,11 +3612,11 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@scalar/agent-chat@0.12.18(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)':
+  '@scalar/agent-chat@0.12.18(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/vue': 3.0.33(vue@3.5.32(typescript@6.0.3))(zod@4.4.3)
-      '@scalar/api-client': 3.13.3(tailwindcss@3.4.16)(typescript@6.0.3)
-      '@scalar/components': 0.27.6(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/api-client': 3.13.3(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/components': 0.27.6(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/json-magic': 0.12.17
@@ -3648,17 +3650,17 @@ snapshots:
       - universal-cookie
       - zod
 
-  '@scalar/api-client@3.13.3(tailwindcss@3.4.16)(typescript@6.0.3)':
+  '@scalar/api-client@3.13.3(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)':
     dependencies:
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.16)
       '@headlessui/vue': 1.7.23(vue@3.5.32(typescript@6.0.3))
-      '@scalar/blocks': 0.1.4(tailwindcss@3.4.16)(typescript@6.0.3)
-      '@scalar/components': 0.27.6(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/blocks': 0.1.4(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/components': 0.27.6(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/oas-utils': 0.19.4(typescript@6.0.3)
       '@scalar/openapi-types': 0.9.1
-      '@scalar/sidebar': 0.9.29(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/sidebar': 0.9.29(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/snippetz': 0.9.21
       '@scalar/themes': 0.16.2
       '@scalar/typebox': 0.1.3
@@ -3676,7 +3678,7 @@ snapshots:
       nanoid: 5.1.7
       pretty-ms: 9.3.0
       radix-vue: 1.9.17(vue@3.5.32(typescript@6.0.3))
-      set-cookie-parser: 2.7.2
+      set-cookie-parser: 3.1.0
       vue: 3.5.32(typescript@6.0.3)
       yaml: 2.8.3
       zod: 4.4.3
@@ -3696,19 +3698,19 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@scalar/api-reference@1.62.5(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)':
+  '@scalar/api-reference@1.62.5(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@headlessui/vue': 1.7.23(vue@3.5.32(typescript@6.0.3))
-      '@scalar/agent-chat': 0.12.18(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)
-      '@scalar/api-client': 3.13.3(tailwindcss@3.4.16)(typescript@6.0.3)
-      '@scalar/blocks': 0.1.4(tailwindcss@3.4.16)(typescript@6.0.3)
-      '@scalar/code-highlight': 0.4.1
-      '@scalar/components': 0.27.6(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/agent-chat': 0.12.18(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)(zod@4.4.3)
+      '@scalar/api-client': 3.13.3(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/blocks': 0.1.4(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/code-highlight': 0.4.1(supports-color@7.2.0)
+      '@scalar/components': 0.27.6(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/oas-utils': 0.19.4(typescript@6.0.3)
       '@scalar/schemas': 0.7.2
-      '@scalar/sidebar': 0.9.29(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/sidebar': 0.9.29(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/snippetz': 0.9.21
       '@scalar/themes': 0.16.2
       '@scalar/types': 0.16.2
@@ -3744,9 +3746,9 @@ snapshots:
     dependencies:
       '@scalar/helpers': 0.9.0
 
-  '@scalar/blocks@0.1.4(tailwindcss@3.4.16)(typescript@6.0.3)':
+  '@scalar/blocks@0.1.4(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.6(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/components': 0.27.6(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/snippetz': 0.9.21
@@ -3762,7 +3764,7 @@ snapshots:
       - tailwindcss
       - typescript
 
-  '@scalar/code-highlight@0.4.1':
+  '@scalar/code-highlight@0.4.1(supports-color@7.2.0)':
     dependencies:
       hast-util-to-text: 4.0.2
       highlight.js: 11.11.1
@@ -3773,8 +3775,8 @@ snapshots:
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-gfm: 4.0.1(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-rehype: 11.1.2
       remark-stringify: 11.0.0
       unified: 11.0.5
@@ -3782,13 +3784,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@scalar/components@0.27.6(tailwindcss@3.4.16)(typescript@6.0.3)':
+  '@scalar/components@0.27.6(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/utils': 0.2.10
       '@floating-ui/vue': 1.1.9(vue@3.5.32(typescript@6.0.3))
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.16)
       '@headlessui/vue': 1.7.23(vue@3.5.32(typescript@6.0.3))
-      '@scalar/code-highlight': 0.4.1
+      '@scalar/code-highlight': 0.4.1(supports-color@7.2.0)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/themes': 0.16.2
@@ -3844,9 +3846,9 @@ snapshots:
       '@scalar/helpers': 0.9.0
       '@scalar/validation': 0.6.0
 
-  '@scalar/sidebar@0.9.29(tailwindcss@3.4.16)(typescript@6.0.3)':
+  '@scalar/sidebar@0.9.29(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.6(tailwindcss@3.4.16)(typescript@6.0.3)
+      '@scalar/components': 0.27.6(supports-color@7.2.0)(tailwindcss@3.4.16)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
       '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/themes': 0.16.2
@@ -4372,9 +4374,11 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4843,9 +4847,9 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  json-schema-resolver@3.0.0:
+  json-schema-resolver@3.0.0(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       fast-uri: 3.1.0
       rfdc: 1.4.1
     transitivePeerDependencies:
@@ -4906,14 +4910,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@7.2.0)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -4931,51 +4935,51 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@7.2.0):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5186,10 +5190,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -5452,21 +5456,21 @@ snapshots:
       hast-util-to-html: 9.0.5
       unified: 11.0.5
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@7.2.0)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@7.2.0):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -5595,6 +5599,8 @@ snapshots:
   semver@7.8.4: {}
 
   set-cookie-parser@2.7.2: {}
+
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,5 @@ allowBuilds:
   vue-demi: true
 
 overrides:
-  set-cookie-parser: 2.7.2
   '@ungap/structured-clone': '>=1.3.1'
   'glob@<=11.1.0': '11.1.0'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance (dependency override removal).

## Summary
Remove the `set-cookie-parser: 2.7.2` pnpm override. Direct and transitive parents now resolve `set-cookie-parser` at 2.7.2 or newer (`light-my-request` stays on 2.7.2; `@scalar/api-client` takes 3.1.0), so the pin is no longer needed.

## Changes
- Drop the `set-cookie-parser` override from `pnpm-workspace.yaml`
- Refresh the lockfile so `@scalar/api-client` can use `set-cookie-parser@3.1.0`

## Verification
- [x] `pnpm build && pnpm test` — 43 files, 490 tests passed; 100% line coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eac2644b-be86-41a5-a985-247349202d0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eac2644b-be86-41a5-a985-247349202d0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

