### PR TITLE
root - chore: upgrade Docker Node.js runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js image as the base
-FROM node:24-alpine
+FROM node:24.19.0-alpine3.24
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
chore — pin the Docker Node.js runtime image.

## Summary
Pin the floating `node:24-alpine` runtime tag to the current concrete image in the same major + Alpine family: `node:24.19.0-alpine3.24` (same digest as `24-alpine` today).

## Changes
- `Dockerfile` `FROM node:24-alpine` → `FROM node:24.19.0-alpine3.24`

## Verification
- [x] `crane digest` for `24-alpine` and `24.19.0-alpine3.24` match (`sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43`)
- [x] Image `NODE_VERSION=24.19.0`; `.nvmrc` is `24`; `engines.node` is `>=22.18.0`
- [x] `pnpm test` — 43 files, 490 tests, 100% line coverage
- [ ] `docker build` — not run here (no Docker daemon in this environment); CI `docker-publish` builds on release

## Breaking notes
None — same image the floating tag currently resolves to.

dependency-management-node → Docker runtime images (Node.js)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eac2644b-be86-41a5-a985-247349202d0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eac2644b-be86-41a5-a985-247349202d0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

